### PR TITLE
Execution Context

### DIFF
--- a/jagrkt-api/build.gradle.kts
+++ b/jagrkt-api/build.gradle.kts
@@ -12,5 +12,6 @@ dependencies {
   api("org.junit.jupiter:junit-jupiter:$junitVersion")
   api("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
   api("org.junit.platform:junit-platform-launcher:1.7.1")
+  api("fr.inria.gforge.spoon:spoon-core:9.0.0")
   implementation("org.jetbrains:annotations:20.1.0")
 }

--- a/jagrkt-api/src/main/java/org/jagrkt/api/executor/ElementPredicate.java
+++ b/jagrkt-api/src/main/java/org/jagrkt/api/executor/ElementPredicate.java
@@ -17,13 +17,29 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package org.jagrkt.common.export
+package org.jagrkt.api.executor;
 
-import org.jagrkt.common.testing.TestJarImpl
-import java.io.File
+import com.google.inject.Inject;
+import org.jagrkt.api.inspect.Element;
+import org.jetbrains.annotations.ApiStatus;
 
-interface Exporter {
-  val name: String
-  fun initialize(directory: File, testJar: TestJarImpl? = null) = Unit
-  fun finalize(directory: File, testJar: TestJarImpl? = null) = Unit
+@FunctionalInterface
+public interface ElementPredicate {
+
+  static ElementPredicate nonOfType(Class<? extends Element> type) {
+    return FactoryProvider.factory.ofType(type);
+  }
+
+  boolean test(Element element);
+
+  @ApiStatus.Internal
+  final class FactoryProvider {
+    @Inject
+    private static Factory factory;
+  }
+
+  @ApiStatus.Internal
+  interface Factory {
+    ElementPredicate ofType(Class<? extends Element> type);
+  }
 }

--- a/jagrkt-api/src/main/java/org/jagrkt/api/executor/ExecutionContext.java
+++ b/jagrkt-api/src/main/java/org/jagrkt/api/executor/ExecutionContext.java
@@ -1,0 +1,48 @@
+/*
+ *   JagrKt - JagrKt.org
+ *   Copyright (C) 2021 Alexander Staeding
+ *   Copyright (C) 2021 Contributors
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jagrkt.api.executor;
+
+import com.google.inject.Inject;
+import org.jagrkt.api.testing.TestCycle;
+import org.jetbrains.annotations.ApiStatus;
+
+public interface ExecutionContext {
+
+  static void runWithVerifiers(Runnable runnable, ExecutionContextVerifier... verifiers) {
+    FactoryProvider.factory.runWithVerifiers(runnable, verifiers);
+  }
+
+  StackTraceElement getAnchor();
+
+  StackTraceElement[] getStackTrace();
+
+  TestCycle getTestCycle();
+
+  @ApiStatus.Internal
+  final class FactoryProvider {
+    @Inject
+    private static Factory factory;
+  }
+
+  @ApiStatus.Internal
+  interface Factory {
+    void runWithVerifiers(Runnable runnable, ExecutionContextVerifier... verifiers);
+  }
+}

--- a/jagrkt-api/src/main/java/org/jagrkt/api/executor/ExecutionContextVerifier.java
+++ b/jagrkt-api/src/main/java/org/jagrkt/api/executor/ExecutionContextVerifier.java
@@ -1,0 +1,48 @@
+/*
+ *   JagrKt - JagrKt.org
+ *   Copyright (C) 2021 Alexander Staeding
+ *   Copyright (C) 2021 Contributors
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jagrkt.api.executor;
+
+import com.google.inject.Inject;
+import org.jetbrains.annotations.ApiStatus;
+
+@FunctionalInterface
+public interface ExecutionContextVerifier {
+
+  static ExecutionContextVerifier ensureNotRecursive() {
+    return FactoryProvider.factory.ensureNotRecursive();
+  }
+
+  /**
+   * @param context The {@link ExecutionContext} to verify
+   * @throws Error (or subclass) if the provided {@link ExecutionContext} does not pass verification
+   */
+  void verify(ExecutionContext context);
+
+  @ApiStatus.Internal
+  final class FactoryProvider {
+    @Inject
+    private static Factory factory;
+  }
+
+  @ApiStatus.Internal
+  interface Factory {
+    ExecutionContextVerifier ensureNotRecursive();
+  }
+}

--- a/jagrkt-api/src/main/java/org/jagrkt/api/executor/ExecutionScope.java
+++ b/jagrkt-api/src/main/java/org/jagrkt/api/executor/ExecutionScope.java
@@ -17,13 +17,14 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package org.jagrkt.common.export
+package org.jagrkt.api.executor;
 
-import org.jagrkt.common.testing.TestJarImpl
-import java.io.File
+import org.jagrkt.api.inspect.Element;
+import org.jetbrains.annotations.ApiStatus;
 
-interface Exporter {
-  val name: String
-  fun initialize(directory: File, testJar: TestJarImpl? = null) = Unit
-  fun finalize(directory: File, testJar: TestJarImpl? = null) = Unit
+@ApiStatus.NonExtendable
+public interface ExecutionScope {
+  void pushElement(Element element);
+
+  ExecutionSnapshot getSnapshot();
 }

--- a/jagrkt-api/src/main/java/org/jagrkt/api/executor/ExecutionScopeRunner.java
+++ b/jagrkt-api/src/main/java/org/jagrkt/api/executor/ExecutionScopeRunner.java
@@ -17,19 +17,28 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package org.jagrkt.common.executor;
+package org.jagrkt.api.executor;
 
 import com.google.inject.Inject;
+import org.jetbrains.annotations.ApiStatus;
 
-public final class ExecutionContextHandler {
+@FunctionalInterface
+public interface ExecutionScopeRunner {
 
-  @Inject
-  private static ExecutionContextFactoryImpl CONTEXTS;
+  static void runWithVerifiers(ExecutionScopeRunner runnable, ExecutionScopeVerifier... verifiers) {
+    FactoryProvider.factory.runWithVerifiers(runnable, verifiers);
+  }
 
-  public static void checkExecutionContext() {
-    final StackTraceElement[] callStack = Thread.currentThread().getStackTrace();
-    for (StackTraceVerifier verifier : CONTEXTS.getOrCreateStack()) {
-      verifier.verify(callStack);
-    }
+  void run(ExecutionScope context);
+
+  @ApiStatus.Internal
+  final class FactoryProvider {
+    @Inject
+    private static Factory factory;
+  }
+
+  @ApiStatus.Internal
+  interface Factory {
+    void runWithVerifiers(ExecutionScopeRunner runnable, ExecutionScopeVerifier... verifiers);
   }
 }

--- a/jagrkt-api/src/main/java/org/jagrkt/api/executor/ExecutionScopeStack.java
+++ b/jagrkt-api/src/main/java/org/jagrkt/api/executor/ExecutionScopeStack.java
@@ -17,13 +17,21 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package org.jagrkt.common.export
+package org.jagrkt.api.executor;
 
-import org.jagrkt.common.testing.TestJarImpl
-import java.io.File
+import org.jagrkt.api.inspect.Element;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
 
-interface Exporter {
-  val name: String
-  fun initialize(directory: File, testJar: TestJarImpl? = null) = Unit
-  fun finalize(directory: File, testJar: TestJarImpl? = null) = Unit
+@ApiStatus.NonExtendable
+public interface ExecutionScopeStack extends Iterable<ExecutionScope> {
+
+  @Nullable ExecutionScope peek();
+
+  default void pushElement(Element element) {
+    ExecutionScope scope = peek();
+    if (scope != null) {
+      scope.pushElement(element);
+    }
+  }
 }

--- a/jagrkt-api/src/main/java/org/jagrkt/api/executor/ExecutionScopeVerifier.java
+++ b/jagrkt-api/src/main/java/org/jagrkt/api/executor/ExecutionScopeVerifier.java
@@ -1,0 +1,54 @@
+/*
+ *   JagrKt - JagrKt.org
+ *   Copyright (C) 2021 Alexander Staeding
+ *   Copyright (C) 2021 Contributors
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jagrkt.api.executor;
+
+import com.google.inject.Inject;
+import org.jetbrains.annotations.ApiStatus;
+
+@FunctionalInterface
+public interface ExecutionScopeVerifier {
+
+  static ExecutionScopeVerifier ensureNotRecursive() {
+    return FactoryProvider.factory.ensureNotRecursive();
+  }
+
+  static ExecutionScopeVerifier ensure(ElementPredicate codeContextPredicate) {
+    return FactoryProvider.factory.ensure(codeContextPredicate);
+  }
+
+  /**
+   * @param scope The {@link ExecutionScope} to verify
+   * @throws Error (or subclass) if the provided {@link ExecutionSnapshot} does not pass verification
+   */
+  void verify(ExecutionScope scope);
+
+  @ApiStatus.Internal
+  final class FactoryProvider {
+    @Inject
+    private static Factory factory;
+  }
+
+  @ApiStatus.Internal
+  interface Factory {
+    ExecutionScopeVerifier ensureNotRecursive();
+
+    ExecutionScopeVerifier ensure(ElementPredicate codeContextPredicate);
+  }
+}

--- a/jagrkt-api/src/main/java/org/jagrkt/api/executor/ExecutionSnapshot.java
+++ b/jagrkt-api/src/main/java/org/jagrkt/api/executor/ExecutionSnapshot.java
@@ -17,13 +17,15 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package org.jagrkt.common.export
+package org.jagrkt.api.executor;
 
-import org.jagrkt.common.testing.TestJarImpl
-import java.io.File
+import org.jagrkt.api.testing.TestCycle;
 
-interface Exporter {
-  val name: String
-  fun initialize(directory: File, testJar: TestJarImpl? = null) = Unit
-  fun finalize(directory: File, testJar: TestJarImpl? = null) = Unit
+public interface ExecutionSnapshot {
+
+  StackTraceElement getAnchor();
+
+  StackTraceElement[] getStackTrace();
+
+  TestCycle getTestCycle();
 }

--- a/jagrkt-api/src/main/java/org/jagrkt/api/executor/ScopeVerificationException.java
+++ b/jagrkt-api/src/main/java/org/jagrkt/api/executor/ScopeVerificationException.java
@@ -17,24 +17,25 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package org.jagrkt.common.executor
+package org.jagrkt.api.executor;
 
-import org.jagrkt.api.executor.ExecutionContext
-import org.jagrkt.api.executor.ExecutionContextVerifier
-import org.opentest4j.AssertionFailedError
+public class ScopeVerificationException extends RuntimeException {
+  public ScopeVerificationException() {
+  }
 
-object NotRecursiveExecutionContextVerifier : ExecutionContextVerifier {
+  public ScopeVerificationException(String message) {
+    super(message);
+  }
 
-  /**
-   * @throws [AssertionFailedError] if [context] is determined to contain recursive elements.
-   */
-  override fun verify(context: ExecutionContext) {
-    val elements = HashSet<StackTraceElement>(context.stackTrace.size)
-    for (element in context.stackTrace) {
-      if (element == context.anchor) break
-      if (!elements.add(element)) {
-        throw AssertionFailedError("Recursive invocation detected @ $element")
-      }
-    }
+  public ScopeVerificationException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public ScopeVerificationException(Throwable cause) {
+    super(cause);
+  }
+
+  public ScopeVerificationException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+    super(message, cause, enableSuppression, writableStackTrace);
   }
 }

--- a/jagrkt-api/src/main/java/org/jagrkt/api/inspect/Element.java
+++ b/jagrkt-api/src/main/java/org/jagrkt/api/inspect/Element.java
@@ -17,13 +17,9 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package org.jagrkt.common.export
+package org.jagrkt.api.inspect;
 
-import org.jagrkt.common.testing.TestJarImpl
-import java.io.File
+public interface Element {
 
-interface Exporter {
-  val name: String
-  fun initialize(directory: File, testJar: TestJarImpl? = null) = Unit
-  fun finalize(directory: File, testJar: TestJarImpl? = null) = Unit
+  int getId();
 }

--- a/jagrkt-api/src/main/java/org/jagrkt/api/inspect/Loop.java
+++ b/jagrkt-api/src/main/java/org/jagrkt/api/inspect/Loop.java
@@ -17,13 +17,7 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package org.jagrkt.common.export
+package org.jagrkt.api.inspect;
 
-import org.jagrkt.common.testing.TestJarImpl
-import java.io.File
-
-interface Exporter {
-  val name: String
-  fun initialize(directory: File, testJar: TestJarImpl? = null) = Unit
-  fun finalize(directory: File, testJar: TestJarImpl? = null) = Unit
+public interface Loop extends Element {
 }

--- a/jagrkt-api/src/main/java/org/jagrkt/api/rubric/Grader.java
+++ b/jagrkt-api/src/main/java/org/jagrkt/api/rubric/Grader.java
@@ -20,6 +20,8 @@
 package org.jagrkt.api.rubric;
 
 import com.google.inject.Inject;
+import org.jagrkt.api.inspect.CodeContext;
+import org.jagrkt.api.inspect.ContextResolver;
 import org.jagrkt.api.testing.TestCycle;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;

--- a/jagrkt-api/src/main/java/org/jagrkt/api/testing/CompiledProgram.java
+++ b/jagrkt-api/src/main/java/org/jagrkt/api/testing/CompiledProgram.java
@@ -17,13 +17,15 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package org.jagrkt.common.export
+package org.jagrkt.api.testing;
 
-import org.jagrkt.common.testing.TestJarImpl
-import java.io.File
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
 
-interface Exporter {
-  val name: String
-  fun initialize(directory: File, testJar: TestJarImpl? = null) = Unit
-  fun finalize(directory: File, testJar: TestJarImpl? = null) = Unit
+@ApiStatus.NonExtendable
+public interface CompiledProgram {
+
+  CompileResult getCompileResult();
+
+  @Nullable SourceFile getSourceFile(String fileName);
 }

--- a/jagrkt-api/src/main/java/org/jagrkt/api/testing/JavaCompiledProgram.java
+++ b/jagrkt-api/src/main/java/org/jagrkt/api/testing/JavaCompiledProgram.java
@@ -17,13 +17,11 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package org.jagrkt.common.export
+package org.jagrkt.api.testing;
 
-import org.jagrkt.common.testing.TestJarImpl
-import java.io.File
+import org.jetbrains.annotations.ApiStatus;
+import spoon.reflect.CtModel;
 
-interface Exporter {
-  val name: String
-  fun initialize(directory: File, testJar: TestJarImpl? = null) = Unit
-  fun finalize(directory: File, testJar: TestJarImpl? = null) = Unit
+@ApiStatus.NonExtendable
+public interface JavaCompiledProgram extends CompiledProgram {
 }

--- a/jagrkt-api/src/main/java/org/jagrkt/api/testing/JavaSourceFile.java
+++ b/jagrkt-api/src/main/java/org/jagrkt/api/testing/JavaSourceFile.java
@@ -17,13 +17,9 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package org.jagrkt.common.export
+package org.jagrkt.api.testing;
 
-import org.jagrkt.common.testing.TestJarImpl
-import java.io.File
+public interface JavaSourceFile extends SourceFile {
 
-interface Exporter {
-  val name: String
-  fun initialize(directory: File, testJar: TestJarImpl? = null) = Unit
-  fun finalize(directory: File, testJar: TestJarImpl? = null) = Unit
+  String getClassName();
 }

--- a/jagrkt-api/src/main/java/org/jagrkt/api/testing/JavaSubmission.java
+++ b/jagrkt-api/src/main/java/org/jagrkt/api/testing/JavaSubmission.java
@@ -17,13 +17,10 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package org.jagrkt.common.export
+package org.jagrkt.api.testing;
 
-import org.jagrkt.common.testing.TestJarImpl
-import java.io.File
+import org.jetbrains.annotations.ApiStatus;
 
-interface Exporter {
-  val name: String
-  fun initialize(directory: File, testJar: TestJarImpl? = null) = Unit
-  fun finalize(directory: File, testJar: TestJarImpl? = null) = Unit
+@ApiStatus.NonExtendable
+public interface JavaSubmission extends Submission, JavaCompiledProgram {
 }

--- a/jagrkt-api/src/main/java/org/jagrkt/api/testing/SourceFile.java
+++ b/jagrkt-api/src/main/java/org/jagrkt/api/testing/SourceFile.java
@@ -29,5 +29,5 @@ public interface SourceFile {
 
   String getContent();
 
-  @Nullable String getClassName();
+  @Nullable JavaSourceFile asJava();
 }

--- a/jagrkt-api/src/main/java/org/jagrkt/api/testing/Submission.java
+++ b/jagrkt-api/src/main/java/org/jagrkt/api/testing/Submission.java
@@ -23,11 +23,7 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
 @ApiStatus.NonExtendable
-public interface Submission {
+public interface Submission extends CompiledProgram {
 
   SubmissionInfo getInfo();
-
-  CompileResult getCompileResult();
-
-  @Nullable SourceFile getSourceFile(String fileName);
 }

--- a/jagrkt-api/src/main/java/org/jagrkt/api/testing/TestCycle.java
+++ b/jagrkt-api/src/main/java/org/jagrkt/api/testing/TestCycle.java
@@ -19,6 +19,7 @@
 
 package org.jagrkt.api.testing;
 
+import org.jagrkt.api.executor.ExecutionScopeStack;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 import org.junit.platform.launcher.TestPlan;
@@ -28,6 +29,8 @@ import java.util.List;
 
 @ApiStatus.NonExtendable
 public interface TestCycle {
+
+  ExecutionScopeStack getExecutionScopes();
 
   List<String> getRubricProviderClassNames();
 
@@ -41,6 +44,11 @@ public interface TestCycle {
 
   Submission getSubmission();
 
+  /**
+   * This will always be {@code null} during execution of JUnit tests as it is not initialized until after they are completed.
+   *
+   * @return The {@link JUnitResult} if present, otherwise null
+   */
   @Nullable JUnitResult getJUnitResult();
 
   @ApiStatus.NonExtendable

--- a/jagrkt-api/src/main/java/org/jagrkt/api/testing/TestJar.java
+++ b/jagrkt-api/src/main/java/org/jagrkt/api/testing/TestJar.java
@@ -17,25 +17,10 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package org.jagrkt.common.testing
+package org.jagrkt.api.testing;
 
-import org.jagrkt.api.testing.CompileResult
-import org.jagrkt.api.testing.SourceFile
-import org.jagrkt.api.testing.Submission
-import org.jagrkt.api.testing.SubmissionInfo
-import org.jagrkt.common.compiler.java.CompiledClass
-import org.jagrkt.common.compiler.java.JavaSourceFile
-import java.io.File
+import org.jetbrains.annotations.ApiStatus;
 
-data class JavaSubmission(
-  val file: File,
-  private val info: SubmissionInfo,
-  private val compileResult: CompileResult,
-  val compiledClasses: Map<String, CompiledClass>,
-  val sourceFiles: Map<String, JavaSourceFile>,
-) : Submission {
-  override fun getInfo(): SubmissionInfo = info
-  override fun getCompileResult(): CompileResult = compileResult
-  override fun getSourceFile(fileName: String): SourceFile? = sourceFiles[fileName]
-  override fun toString(): String = "$info(${file.name})"
+@ApiStatus.NonExtendable
+public interface TestJar extends CompiledProgram {
 }

--- a/jagrkt-api/src/main/java/org/jagrkt/api/testing/TestStatusListener.java
+++ b/jagrkt-api/src/main/java/org/jagrkt/api/testing/TestStatusListener.java
@@ -19,11 +19,13 @@
 
 package org.jagrkt.api.testing;
 
+import org.jetbrains.annotations.ApiStatus;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.launcher.TestIdentifier;
 
 import java.util.Map;
 
+@ApiStatus.NonExtendable
 public interface TestStatusListener {
 
   Map<TestIdentifier, TestExecutionResult> getTestResults();

--- a/jagrkt-api/src/main/java/org/jagrkt/api/testing/extension/TestCycleResolver.java
+++ b/jagrkt-api/src/main/java/org/jagrkt/api/testing/extension/TestCycleResolver.java
@@ -20,6 +20,10 @@
 package org.jagrkt.api.testing.extension;
 
 import com.google.inject.Inject;
+import org.jagrkt.api.executor.ElementPredicate;
+import org.jagrkt.api.executor.ExecutionScopeRunner;
+import org.jagrkt.api.executor.ExecutionScopeVerifier;
+import org.jagrkt.api.inspect.Loop;
 import org.jetbrains.annotations.ApiStatus;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
@@ -30,6 +34,9 @@ public final class TestCycleResolver implements ParameterResolver {
 
   @Override
   public final boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+    ExecutionScopeRunner.runWithVerifiers(scope1 -> {
+
+    }, ExecutionScopeVerifier.ensure(ElementPredicate.nonOfType(Loop.class)));
     return Provider.parameterResolver.supportsParameter(parameterContext, extensionContext);
   }
 

--- a/jagrkt-api/src/test/java/org/jagrkt/api/IntegrationTest.java
+++ b/jagrkt-api/src/test/java/org/jagrkt/api/IntegrationTest.java
@@ -17,15 +17,24 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package org.jagrkt.common.executor
+package org.jagrkt.api;
 
-import org.jagrkt.api.testing.TestCycle
+import org.jagrkt.api.inspect.ContextResolver;
+import org.jagrkt.api.inspect.JavaMethodContext;
+import org.jagrkt.api.testing.TestCycle;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
-data class LightExecutionContext(
-  val anchor: StackTraceElement,
-  val testCycle: TestCycle,
-) {
-  fun withStackTrace(stackTrace: Array<out StackTraceElement>): ExecutionContextImpl {
-    return ExecutionContextImpl(anchor, stackTrace, testCycle)
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class IntegrationTest {
+
+  @Test
+  @DisplayName("Fib Iterative Correct")
+  public void fibIterative(TestCycle testCycle) {
+    JavaMethodContext ctx = ContextResolver.ofJavaMethod(() -> Solution.class.getMethod("bar", int.class))
+      .resolve(testCycle);
+    assertTrue(ctx.modified());
+    assertTrue(ctx.getModifiedSource().contains("for"));
   }
 }

--- a/jagrkt-api/src/test/java/org/jagrkt/api/Solution.java
+++ b/jagrkt-api/src/test/java/org/jagrkt/api/Solution.java
@@ -17,32 +17,11 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package org.jagrkt.api.executor;
+package org.jagrkt.api;
 
-import com.google.inject.Inject;
-import org.jetbrains.annotations.ApiStatus;
+public class Solution {
 
-@FunctionalInterface
-public interface ExecutionContextVerifier {
+  public static void bar(int foo) {
 
-  static ExecutionContextVerifier ensureNotRecursive() {
-    return FactoryProvider.factory.ensureNotRecursive();
-  }
-
-  /**
-   * @param context The {@link ExecutionContext} to verify
-   * @throws Error (or subclass) if the provided {@link ExecutionContext} does not pass verification
-   */
-  void verify(ExecutionContext context);
-
-  @ApiStatus.Internal
-  final class FactoryProvider {
-    @Inject
-    private static Factory factory;
-  }
-
-  @ApiStatus.Internal
-  interface Factory {
-    ExecutionContextVerifier ensureNotRecursive();
   }
 }

--- a/jagrkt-common/build.gradle.kts
+++ b/jagrkt-common/build.gradle.kts
@@ -17,7 +17,9 @@ dependencies {
   implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
   implementation("org.apache.logging.log4j:log4j-slf4j-impl:2.14.0")
   implementation("org.fusesource.jansi:jansi:2.3.1")
-  implementation("org.ow2.asm:asm:9.1")
+  val asmVersion = "9.1"
+  implementation("org.ow2.asm:asm:$asmVersion")
+  implementation("org.ow2.asm:asm-tree:$asmVersion")
   implementation("com.github.albfernandez:juniversalchardet:2.4.0")
   val configurateVersion = "4.1.1"
   implementation("org.spongepowered:configurate-hocon:$configurateVersion")

--- a/jagrkt-common/src/main/java/org/jagrkt/common/executor/ExecutionContextHandler.java
+++ b/jagrkt-common/src/main/java/org/jagrkt/common/executor/ExecutionContextHandler.java
@@ -1,0 +1,35 @@
+/*
+ *   JagrKt - JagrKt.org
+ *   Copyright (C) 2021 Alexander Staeding
+ *   Copyright (C) 2021 Contributors
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jagrkt.common.executor;
+
+import com.google.inject.Inject;
+
+public final class ExecutionContextHandler {
+
+  @Inject
+  private static ExecutionContextFactoryImpl CONTEXTS;
+
+  public static void checkExecutionContext() {
+    final StackTraceElement[] callStack = Thread.currentThread().getStackTrace();
+    for (StackTraceVerifier verifier : CONTEXTS.getOrCreateStack()) {
+      verifier.verify(callStack);
+    }
+  }
+}

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/CommonModule.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/CommonModule.kt
@@ -20,6 +20,7 @@
 package org.jagrkt.common
 
 import com.google.inject.AbstractModule
+import org.jagrkt.api.executor.*
 import org.jagrkt.api.rubric.*
 import org.jagrkt.api.testing.extension.*
 import org.jagrkt.common.executor.*
@@ -32,6 +33,8 @@ import org.jagrkt.common.testing.*
  */
 abstract class CommonModule : AbstractModule() {
   override fun configure() {
+    bind(ExecutionContext.Factory::class.java).to(ExecutionContextFactoryImpl::class.java)
+    bind(ExecutionContextVerifier.Factory::class.java).to(ExecutionContextVerifierFactoryImpl::class.java)
     bind(Criterion.Factory::class.java).to(CriterionFactoryImpl::class.java)
     bind(CriterionHolderPointCalculator.Factory::class.java).to(CriterionHolderPointCalculatorFactoryImpl::class.java)
     bind(Grader.Factory::class.java).to(GraderFactoryImpl::class.java)
@@ -41,6 +44,9 @@ abstract class CommonModule : AbstractModule() {
     bind(TestCycleResolver.Internal::class.java).to(TestCycleParameterResolver::class.java)
 
     requestStaticInjection(
+      ExecutionContextHandler::class.java,
+      ExecutionContext.FactoryProvider::class.java,
+      ExecutionContextVerifier.FactoryProvider::class.java,
       Criterion.FactoryProvider::class.java,
       CriterionHolderPointCalculator.FactoryProvider::class.java,
       Grader.FactoryProvider::class.java,

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/CommonModule.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/CommonModule.kt
@@ -33,8 +33,8 @@ import org.jagrkt.common.testing.*
  */
 abstract class CommonModule : AbstractModule() {
   override fun configure() {
-    bind(ExecutionContext.Factory::class.java).to(ExecutionContextFactoryImpl::class.java)
-    bind(ExecutionContextVerifier.Factory::class.java).to(ExecutionContextVerifierFactoryImpl::class.java)
+    bind(ExecutionSnapshot.Factory::class.java).to(ExecutionContextFactoryImpl::class.java)
+    bind(ExecutionScopeVerifier.Factory::class.java).to(ExecutionContextVerifierFactoryImpl::class.java)
     bind(Criterion.Factory::class.java).to(CriterionFactoryImpl::class.java)
     bind(CriterionHolderPointCalculator.Factory::class.java).to(CriterionHolderPointCalculatorFactoryImpl::class.java)
     bind(Grader.Factory::class.java).to(GraderFactoryImpl::class.java)
@@ -45,8 +45,8 @@ abstract class CommonModule : AbstractModule() {
 
     requestStaticInjection(
       ExecutionContextHandler::class.java,
-      ExecutionContext.FactoryProvider::class.java,
-      ExecutionContextVerifier.FactoryProvider::class.java,
+      ExecutionSnapshot.FactoryProvider::class.java,
+      ExecutionScopeVerifier.FactoryProvider::class.java,
       Criterion.FactoryProvider::class.java,
       CriterionHolderPointCalculator.FactoryProvider::class.java,
       Grader.FactoryProvider::class.java,

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/Config.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/Config.kt
@@ -80,6 +80,10 @@ class Transformers {
   }
 
   @ConfigSerializable
+  class CallStackTransformer : Transformer() {
+  }
+
+  @ConfigSerializable
   class TimeoutTransformer : Transformer() {
     @Comment(
       """
@@ -102,6 +106,8 @@ invocations of checkTimeout() will result in an AssertionFailedError
     )
     val totalTimeout = 150_000L
   }
+
+  val callStack = CallStackTransformer()
 
   val timeout = TimeoutTransformer()
 }

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/compiler/java/JavaCompileResult.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/compiler/java/JavaCompileResult.kt
@@ -1,0 +1,57 @@
+/*
+ *   JagrKt - JagrKt.org
+ *   Copyright (C) 2021 Alexander Staeding
+ *   Copyright (C) 2021 Contributors
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jagrkt.common.compiler.java
+
+import org.jagrkt.api.inspect.Element
+import org.jagrkt.api.testing.CompileResult
+import org.jagrkt.common.testing.SubmissionInfoImpl
+import org.slf4j.Logger
+import java.io.File
+
+data class JavaCompileResult(
+  val file: File,
+  val submissionInfo: SubmissionInfoImpl? = null,
+  val sourceFiles: Map<String, JavaSourceFile> = mapOf(),
+  val compiledClasses: Map<String, CompiledClass> = mapOf(),
+  val libClasses: Map<String, CompiledClass> = mapOf(),
+  val elementTable: Array<Element> = emptyArray(),
+  private val messages: List<String> = listOf(),
+  private val warningCount: Int = 0,
+  private val errorCount: Int = 0,
+  private val otherCount: Int = 0,
+) : CompileResult {
+  override fun getMessages(): List<String> = messages
+  override fun getWarningCount(): Int = warningCount
+  override fun getErrorCount(): Int = errorCount
+  override fun getOtherCount(): Int = otherCount
+
+  fun printMessages(logger: Logger, lazyError: () -> String, lazyWarning: () -> String) {
+    when {
+      errorCount > 0 -> {
+        logger.error(lazyError())
+        messages.forEach(logger::error)
+      }
+      warningCount > 0 -> {
+        logger.warn(lazyWarning())
+        messages.forEach(logger::warn)
+      }
+    }
+  }
+}

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/compiler/java/RuntimeJarLoader.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/compiler/java/RuntimeJarLoader.kt
@@ -22,7 +22,6 @@ package org.jagrkt.common.compiler.java
 import com.google.inject.Inject
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
-import org.jagrkt.api.testing.CompileResult
 import org.jagrkt.common.compiler.readEncoded
 import org.jagrkt.common.testing.SubmissionInfoImpl
 import org.objectweb.asm.ClassReader
@@ -60,7 +59,7 @@ class RuntimeJarLoader @Inject constructor(
     return classStorage
   }
 
-  fun loadSourcesJar(file: File, runtimeClassPath: Map<String, CompiledClass> = mapOf()): CompileJarResult {
+  fun loadSourcesJar(file: File, libClasses: Map<String, CompiledClass> = mapOf()): JavaCompileResult {
     val jarFile = JarFile(file)
     val sourceFiles: MutableMap<String, JavaSourceFile> = mutableMapOf()
     var submissionInfo: SubmissionInfoImpl? = null
@@ -72,7 +71,7 @@ class RuntimeJarLoader @Inject constructor(
             Json.decodeFromString<SubmissionInfoImpl>(jarFile.getInputStream(entry).bufferedReader().use { it.readText() })
           } catch (e: Throwable) {
             logger.error("$file has invalid submission-info.json", e)
-            return CompileJarResult(file)
+            return JavaCompileResult(file)
           }
         }
         entry.name.endsWith(".java") -> {
@@ -88,14 +87,14 @@ class RuntimeJarLoader @Inject constructor(
     }
     if (sourceFiles.isEmpty()) {
       // no source files, skip compilation task
-      return CompileJarResult(file, submissionInfo)
+      return JavaCompileResult(file, submissionInfo)
     }
     val compiledClasses: MutableMap<String, CompiledClass> = mutableMapOf()
     val collector = DiagnosticCollector<JavaFileObject>()
     val compiler = ToolProvider.getSystemJavaCompiler()
     val fileManager = ExtendedStandardJavaFileManager(
       compiler.getStandardFileManager(null, null, StandardCharsets.UTF_8),
-      runtimeClassPath,
+      libClasses,
       compiledClasses,
     )
     val result = compiler.getTask(null, fileManager, collector, null, null, sourceFiles.values).call()
@@ -117,9 +116,9 @@ class RuntimeJarLoader @Inject constructor(
         }
         messages += "${diag.source.name}:${diag.lineNumber} ${diag.kind} :: ${diag.getMessage(Locale.getDefault())}"
       }
-      return CompileJarResult(file, submissionInfo, compiledClasses, sourceFiles, messages, warnings, errors, other)
+      return JavaCompileResult(file, submissionInfo, sourceFiles, compiledClasses, libClasses, messages, warnings, errors, other)
     }
-    return CompileJarResult(file, submissionInfo, compiledClasses, sourceFiles)
+    return JavaCompileResult(file, submissionInfo, sourceFiles, compiledClasses, libClasses)
   }
 
   private fun Map<String, CompiledClass>.linkSource(sourceFiles: Map<String, JavaSourceFile>) {
@@ -142,58 +141,5 @@ class RuntimeJarLoader @Inject constructor(
         }, ClassReader.SKIP_CODE)
       }
     }
-  }
-
-  data class CompileJarResult(
-    val file: File,
-    val submissionInfo: SubmissionInfoImpl? = null,
-    val compiledClasses: Map<String, CompiledClass> = mapOf(),
-    val sourceFiles: Map<String, JavaSourceFile> = mapOf(),
-    private val messages: List<String> = listOf(),
-    val warnings: Int = 0,
-    val errors: Int = 0,
-    val other: Int = 0,
-  ) : CompileResult {
-    override fun getMessages(): List<String> = messages
-    override fun getWarningCount(): Int = warnings
-    override fun getErrorCount(): Int = errors
-    override fun getOtherCount(): Int = other
-
-    fun printMessages(logger: Logger, lazyError: () -> String, lazyWarning: () -> String) {
-      when {
-        errors > 0 -> {
-          logger.error(lazyError())
-          for (message in messages) {
-            logger.error(message)
-          }
-        }
-        warnings > 0 -> {
-          logger.warn(lazyWarning())
-          for (message in messages) {
-            logger.warn(message)
-          }
-        }
-      }
-    }
-
-    fun copyWith(
-      file: File? = null,
-      submissionInfo: SubmissionInfoImpl? = null,
-      compiledClasses: Map<String, CompiledClass>? = null,
-      sourceFiles: Map<String, JavaSourceFile>? = null,
-      messages: List<String>? = null,
-      warnings: Int? = null,
-      errors: Int? = null,
-      other: Int? = null,
-    ) = CompileJarResult(
-      file ?: this.file,
-      submissionInfo ?: this.submissionInfo,
-      compiledClasses ?: this.compiledClasses,
-      sourceFiles ?: this.sourceFiles,
-      messages ?: this.messages,
-      warnings ?: this.warnings,
-      errors ?: this.errors,
-      other ?: this.other,
-    )
   }
 }

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/executor/ExecutionContextFactoryImpl.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/executor/ExecutionContextFactoryImpl.kt
@@ -1,0 +1,54 @@
+/*
+ *   JagrKt - JagrKt.org
+ *   Copyright (C) 2021 Alexander Staeding
+ *   Copyright (C) 2021 Contributors
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jagrkt.common.executor
+
+import com.google.inject.Inject
+import com.google.inject.Singleton
+import org.jagrkt.api.executor.ExecutionContext
+import org.jagrkt.api.executor.ExecutionContextVerifier
+import org.jagrkt.common.testing.TestCycleParameterResolver
+import java.util.ArrayDeque
+import java.util.Deque
+
+@Singleton
+class ExecutionContextFactoryImpl @Inject constructor(
+  private val testCycleParameterResolver: TestCycleParameterResolver
+) : ExecutionContext.Factory {
+
+  private val stacks: InheritableThreadLocal<Deque<StackTraceVerifier>> = InheritableThreadLocal()
+
+  fun getOrCreateStack(): Deque<StackTraceVerifier> {
+    return stacks.get() ?: ArrayDeque<StackTraceVerifier>().also(stacks::set)
+  }
+
+  override fun runWithVerifiers(runnable: Runnable, vararg verifiers: ExecutionContextVerifier) {
+    val stack = getOrCreateStack()
+    val context = LightExecutionContext(
+      Thread.currentThread().stackTrace[2],
+      testCycleParameterResolver.value,
+    )
+    stack.push(verifiers.withAnchor(context))
+    try {
+      runnable.run()
+    } finally {
+      stack.pop()
+    }
+  }
+}

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/executor/ExecutionContextHandler.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/executor/ExecutionContextHandler.kt
@@ -16,33 +16,17 @@
  *     You should have received a copy of the GNU Lesser General Public License
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+package org.jagrkt.common.executor
 
-package org.jagrkt.api.executor;
+import org.jagrkt.common.inspect.ExecutionScopeImpl
+import org.jagrkt.common.testing.TestCycleParameterResolver
 
-import com.google.inject.Inject;
-import org.jagrkt.api.testing.TestCycle;
-import org.jetbrains.annotations.ApiStatus;
-
-public interface ExecutionContext {
-
-  static void runWithVerifiers(Runnable runnable, ExecutionContextVerifier... verifiers) {
-    FactoryProvider.factory.runWithVerifiers(runnable, verifiers);
-  }
-
-  StackTraceElement getAnchor();
-
-  StackTraceElement[] getStackTrace();
-
-  TestCycle getTestCycle();
-
-  @ApiStatus.Internal
-  final class FactoryProvider {
-    @Inject
-    private static Factory factory;
-  }
-
-  @ApiStatus.Internal
-  interface Factory {
-    void runWithVerifiers(Runnable runnable, ExecutionContextVerifier... verifiers);
+object ExecutionContextHandler {
+  fun checkExecutionContext() {
+    val callStack = Thread.currentThread().stackTrace
+    for (verifier in CONTEXTS.getOrCreateStack()) {
+      verifier.verify(callStack)
+    }
+    (TestCycleParameterResolver.value.executionScopes.peek() as ExecutionScopeImpl?)?.snapshot =
   }
 }

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/executor/ExecutionContextImpl.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/executor/ExecutionContextImpl.kt
@@ -1,0 +1,49 @@
+/*
+ *   JagrKt - JagrKt.org
+ *   Copyright (C) 2021 Alexander Staeding
+ *   Copyright (C) 2021 Contributors
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jagrkt.common.executor
+
+import org.jagrkt.api.executor.ExecutionContext
+import org.jagrkt.api.testing.TestCycle
+
+data class ExecutionContextImpl(
+  private val anchor: StackTraceElement,
+  private val stackTrace: Array<out StackTraceElement>,
+  private val testCycle: TestCycle,
+): ExecutionContext {
+  override fun getAnchor(): StackTraceElement = anchor
+  override fun getStackTrace(): Array<out StackTraceElement> = stackTrace
+  override fun getTestCycle(): TestCycle = testCycle
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (javaClass != other?.javaClass) return false
+    other as ExecutionContextImpl
+    if (anchor != other.anchor) return false
+    if (!stackTrace.contentEquals(other.stackTrace)) return false
+    if (testCycle != other.testCycle) return false
+    return true
+  }
+
+  override fun hashCode(): Int {
+    var result = anchor.hashCode()
+    result = 31 * result + stackTrace.contentHashCode()
+    result = 31 * result + testCycle.hashCode()
+    return result
+  }
+}

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/executor/ExecutionContextVerifierFactoryImpl.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/executor/ExecutionContextVerifierFactoryImpl.kt
@@ -19,8 +19,8 @@
 
 package org.jagrkt.common.executor
 
-import org.jagrkt.api.executor.ExecutionContextVerifier
+import org.jagrkt.api.executor.ExecutionScopeVerifier
 
-class ExecutionContextVerifierFactoryImpl : ExecutionContextVerifier.Factory {
-  override fun ensureNotRecursive(): ExecutionContextVerifier = NotRecursiveExecutionContextVerifier
+class ExecutionContextVerifierFactoryImpl : ExecutionScopeVerifier.Factory {
+  override fun ensureNotRecursive(): ExecutionScopeVerifier = NotRecursiveExecutionScopeVerifier
 }

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/executor/ExecutionContextVerifierFactoryImpl.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/executor/ExecutionContextVerifierFactoryImpl.kt
@@ -1,0 +1,26 @@
+/*
+ *   JagrKt - JagrKt.org
+ *   Copyright (C) 2021 Alexander Staeding
+ *   Copyright (C) 2021 Contributors
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jagrkt.common.executor
+
+import org.jagrkt.api.executor.ExecutionContextVerifier
+
+class ExecutionContextVerifierFactoryImpl : ExecutionContextVerifier.Factory {
+  override fun ensureNotRecursive(): ExecutionContextVerifier = NotRecursiveExecutionContextVerifier
+}

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/executor/ExecutionScopeStackImpl.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/executor/ExecutionScopeStackImpl.kt
@@ -17,13 +17,13 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package org.jagrkt.common.export
+package org.jagrkt.common.executor
 
-import org.jagrkt.common.testing.TestJarImpl
-import java.io.File
+import org.jagrkt.api.executor.ExecutionScope
+import org.jagrkt.api.executor.ExecutionScopeStack
+import java.util.ArrayDeque
+import java.util.Deque
 
-interface Exporter {
-  val name: String
-  fun initialize(directory: File, testJar: TestJarImpl? = null) = Unit
-  fun finalize(directory: File, testJar: TestJarImpl? = null) = Unit
+class ExecutionScopeStackImpl : ExecutionScopeStack, Deque<ExecutionScope> by ArrayDeque() {
+
 }

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/executor/ExecutionSnapshotImpl.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/executor/ExecutionSnapshotImpl.kt
@@ -19,31 +19,15 @@
 
 package org.jagrkt.common.executor
 
-import org.jagrkt.api.executor.ExecutionContext
+import org.jagrkt.api.executor.ExecutionSnapshot
 import org.jagrkt.api.testing.TestCycle
 
-data class ExecutionContextImpl(
+data class ExecutionSnapshotImpl(
   private val anchor: StackTraceElement,
   private val stackTrace: Array<out StackTraceElement>,
   private val testCycle: TestCycle,
-): ExecutionContext {
+): ExecutionSnapshot {
   override fun getAnchor(): StackTraceElement = anchor
   override fun getStackTrace(): Array<out StackTraceElement> = stackTrace
   override fun getTestCycle(): TestCycle = testCycle
-  override fun equals(other: Any?): Boolean {
-    if (this === other) return true
-    if (javaClass != other?.javaClass) return false
-    other as ExecutionContextImpl
-    if (anchor != other.anchor) return false
-    if (!stackTrace.contentEquals(other.stackTrace)) return false
-    if (testCycle != other.testCycle) return false
-    return true
-  }
-
-  override fun hashCode(): Int {
-    var result = anchor.hashCode()
-    result = 31 * result + stackTrace.contentHashCode()
-    result = 31 * result + testCycle.hashCode()
-    return result
-  }
 }

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/executor/LightExecutionContext.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/executor/LightExecutionContext.kt
@@ -1,0 +1,31 @@
+/*
+ *   JagrKt - JagrKt.org
+ *   Copyright (C) 2021 Alexander Staeding
+ *   Copyright (C) 2021 Contributors
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jagrkt.common.executor
+
+import org.jagrkt.api.testing.TestCycle
+
+data class LightExecutionContext(
+  val anchor: StackTraceElement,
+  val testCycle: TestCycle,
+) {
+  fun withStackTrace(stackTrace: Array<out StackTraceElement>): ExecutionContextImpl {
+    return ExecutionContextImpl(anchor, stackTrace, testCycle)
+  }
+}

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/executor/LightExecutionSnapshot.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/executor/LightExecutionSnapshot.kt
@@ -17,13 +17,15 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package org.jagrkt.common.export
+package org.jagrkt.common.executor
 
-import org.jagrkt.common.testing.TestJarImpl
-import java.io.File
+import org.jagrkt.api.testing.TestCycle
 
-interface Exporter {
-  val name: String
-  fun initialize(directory: File, testJar: TestJarImpl? = null) = Unit
-  fun finalize(directory: File, testJar: TestJarImpl? = null) = Unit
+data class LightExecutionSnapshot(
+  val anchor: StackTraceElement,
+  val testCycle: TestCycle,
+) {
+  fun withStackTrace(stackTrace: Array<out StackTraceElement>): ExecutionSnapshotImpl {
+    return ExecutionSnapshotImpl(anchor, stackTrace, testCycle)
+  }
 }

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/executor/NotRecursiveExecutionContextVerifier.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/executor/NotRecursiveExecutionContextVerifier.kt
@@ -1,0 +1,40 @@
+/*
+ *   JagrKt - JagrKt.org
+ *   Copyright (C) 2021 Alexander Staeding
+ *   Copyright (C) 2021 Contributors
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jagrkt.common.executor
+
+import org.jagrkt.api.executor.ExecutionContext
+import org.jagrkt.api.executor.ExecutionContextVerifier
+import org.opentest4j.AssertionFailedError
+
+object NotRecursiveExecutionContextVerifier : ExecutionContextVerifier {
+
+  /**
+   * @throws [AssertionFailedError] if [context] is determined to contain recursive elements.
+   */
+  override fun verify(context: ExecutionContext) {
+    val elements = HashSet<StackTraceElement>(context.stackTrace.size)
+    for (element in context.stackTrace) {
+      if (element == context.anchor) break
+      if (!elements.add(element)) {
+        throw AssertionFailedError("Recursive invocation detected @ $element")
+      }
+    }
+  }
+}

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/executor/StackTraceVerifier.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/executor/StackTraceVerifier.kt
@@ -1,0 +1,57 @@
+/*
+ *   JagrKt - JagrKt.org
+ *   Copyright (C) 2021 Alexander Staeding
+ *   Copyright (C) 2021 Contributors
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jagrkt.common.executor
+
+import org.jagrkt.api.executor.ExecutionContextVerifier
+
+interface StackTraceVerifier {
+  fun verify(stackTrace: Array<out StackTraceElement>)
+}
+
+private object AnchoredEmptyExecutionContextVerifier : StackTraceVerifier {
+  override fun verify(stackTrace: Array<out StackTraceElement>) {}
+}
+
+private class AnchoredSingleExecutionContextVerifier(
+  private val context: LightExecutionContext,
+  private val verifier: ExecutionContextVerifier,
+) : StackTraceVerifier {
+  override fun verify(stackTrace: Array<out StackTraceElement>) = verifier.verify(context.withStackTrace(stackTrace))
+}
+
+private class AnchoredManyExecutionContextVerifier(
+  private val context: LightExecutionContext,
+  private val verifiers: Array<out ExecutionContextVerifier>,
+) : StackTraceVerifier {
+  override fun verify(stackTrace: Array<out StackTraceElement>) {
+    val context = context.withStackTrace(stackTrace)
+    for (verifier in verifiers) {
+      verifier.verify(context)
+    }
+  }
+}
+
+fun Array<out ExecutionContextVerifier>.withAnchor(context: LightExecutionContext): StackTraceVerifier {
+  return when (size) {
+    0 -> AnchoredEmptyExecutionContextVerifier
+    1 -> AnchoredSingleExecutionContextVerifier(context, this[0])
+    else -> AnchoredManyExecutionContextVerifier(context, this)
+  }
+}

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/export/ExportManager.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/export/ExportManager.kt
@@ -20,7 +20,7 @@
 package org.jagrkt.common.export
 
 import org.jagrkt.common.ensure
-import org.jagrkt.common.testing.TestJar
+import org.jagrkt.common.testing.TestJarImpl
 import org.slf4j.Logger
 import java.io.File
 
@@ -29,7 +29,7 @@ abstract class ExportManager<E : Exporter> {
   protected abstract val logger: Logger
   protected abstract val exporters: Set<E>
 
-  fun initialize(directory: File, testJars: List<TestJar>) {
+  fun initialize(directory: File, testJars: List<TestJarImpl>) {
     for (exporter in exporters) {
       val exportDir = directory.resolve(exporter.name).ensure(logger) ?: continue
       exportDir.resolve("default").ensure(logger) ?: continue
@@ -41,7 +41,7 @@ abstract class ExportManager<E : Exporter> {
     }
   }
 
-  fun finalize(directory: File, testJars: List<TestJar>) {
+  fun finalize(directory: File, testJars: List<TestJarImpl>) {
     for (exporter in exporters) {
       val exportDir = directory.resolve(exporter.name)
       exporter.finalize(exportDir.resolve("default"))

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/export/submission/EclipseSubmissionExporter.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/export/submission/EclipseSubmissionExporter.kt
@@ -22,8 +22,8 @@ package org.jagrkt.common.export.submission
 import com.google.inject.Inject
 import org.jagrkt.api.testing.Submission
 import org.jagrkt.common.ensure
-import org.jagrkt.common.testing.JavaSubmission
-import org.jagrkt.common.testing.TestJar
+import org.jagrkt.common.testing.JavaSubmissionImpl
+import org.jagrkt.common.testing.TestJarImpl
 import org.jagrkt.common.writeTextSafe
 import org.slf4j.Logger
 import java.io.File
@@ -33,8 +33,8 @@ class EclipseSubmissionExporter @Inject constructor(
   private val logger: Logger,
 ) : SubmissionExporter {
   override val name: String = "eclipse"
-  override fun export(submission: Submission, directory: File, testJar: TestJar?) {
-    if (submission !is JavaSubmission) return
+  override fun export(submission: Submission, directory: File, testJar: TestJarImpl?) {
+    if (submission !is JavaSubmissionImpl) return
     val file = directory.resolve(submission.info.toString()).ensure(logger, false) ?: return
     val src = file.resolve("src").ensure(logger, false) ?: return
     writeProjectFile(submission, file.resolve(".project"))
@@ -45,7 +45,7 @@ class EclipseSubmissionExporter @Inject constructor(
     }
   }
 
-  private fun writeProjectFile(submission: JavaSubmission, file: File) {
+  private fun writeProjectFile(submission: JavaSubmissionImpl, file: File) {
     val writer = PrintWriter(file, "UTF-8")
     writer.println("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
     writer.println("<projectDescription>")
@@ -62,7 +62,7 @@ class EclipseSubmissionExporter @Inject constructor(
     writer.flush()
   }
 
-  private fun writeClasspathFile(submission: JavaSubmission, file: File) {
+  private fun writeClasspathFile(submission: JavaSubmissionImpl, file: File) {
     val writer = PrintWriter(file, "UTF-8")
     writer.println("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
     writer.println("<classpath>")

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/export/submission/GradleSubmissionExporter.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/export/submission/GradleSubmissionExporter.kt
@@ -27,9 +27,9 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.jagrkt.api.testing.Submission
 import org.jagrkt.common.ensure
-import org.jagrkt.common.testing.JavaSubmission
+import org.jagrkt.common.testing.JavaSubmissionImpl
 import org.jagrkt.common.testing.SubmissionInfoImpl
-import org.jagrkt.common.testing.TestJar
+import org.jagrkt.common.testing.TestJarImpl
 import org.jagrkt.common.usePrintWriterSafe
 import org.jagrkt.common.writeStream
 import org.jagrkt.common.writeTextSafe
@@ -90,7 +90,7 @@ class GradleSubmissionExporter @Inject constructor(
     writeGradleResource(classLoader, resource = "gradle-wrapper.properties", targetDir = "gradle/wrapper/")
   }
 
-  override fun initialize(directory: File, testJar: TestJar?) {
+  override fun initialize(directory: File, testJar: TestJarImpl?) {
     directory.writeSkeleton()
   }
 
@@ -103,12 +103,12 @@ class GradleSubmissionExporter @Inject constructor(
     }
   }
 
-  override fun finalize(directory: File, testJar: TestJar?) {
+  override fun finalize(directory: File, testJar: TestJarImpl?) {
     writeSettings(directory, testJar?.name)
   }
 
-  override fun export(submission: Submission, directory: File, testJar: TestJar?) {
-    if (submission !is JavaSubmission) return
+  override fun export(submission: Submission, directory: File, testJar: TestJarImpl?) {
+    if (submission !is JavaSubmissionImpl) return
     val submissionName = submission.info.toString()
     val file = directory.resolve(submissionName).ensure(logger, false) ?: return
     val mainResources = file.resolve("src/main/resources").ensure(logger, false) ?: return

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/export/submission/SubmissionExportManager.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/export/submission/SubmissionExportManager.kt
@@ -22,7 +22,7 @@ package org.jagrkt.common.export.submission
 import com.google.inject.Inject
 import org.jagrkt.api.testing.Submission
 import org.jagrkt.common.export.ExportManager
-import org.jagrkt.common.testing.TestJar
+import org.jagrkt.common.testing.TestJarImpl
 import org.slf4j.Logger
 import java.io.File
 
@@ -30,7 +30,7 @@ class SubmissionExportManager @Inject constructor(
   override val logger: Logger,
   override val exporters: Set<SubmissionExporter>,
 ) : ExportManager<SubmissionExporter>() {
-  fun export(submission: Submission, directory: File, testJars: List<TestJar>) {
+  fun export(submission: Submission, directory: File, testJars: List<TestJarImpl>) {
     for (exporter in exporters) {
       val exportDir = directory.resolve(exporter.name)
       exporter.export(submission, exportDir.resolve("default"))

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/export/submission/SubmissionExporter.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/export/submission/SubmissionExporter.kt
@@ -21,9 +21,9 @@ package org.jagrkt.common.export.submission
 
 import org.jagrkt.api.testing.Submission
 import org.jagrkt.common.export.Exporter
-import org.jagrkt.common.testing.TestJar
+import org.jagrkt.common.testing.TestJarImpl
 import java.io.File
 
 interface SubmissionExporter : Exporter {
-  fun export(submission: Submission, directory: File, testJar: TestJar? = null)
+  fun export(submission: Submission, directory: File, testJar: TestJarImpl? = null)
 }

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/inspect/ElementIdVerifier.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/inspect/ElementIdVerifier.kt
@@ -17,13 +17,16 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package org.jagrkt.common.export
+package org.jagrkt.common.inspect
 
-import org.jagrkt.common.testing.TestJarImpl
-import java.io.File
+import org.jagrkt.api.executor.ElementPredicate
+import org.jagrkt.api.inspect.Element
 
-interface Exporter {
-  val name: String
-  fun initialize(directory: File, testJar: TestJarImpl? = null) = Unit
-  fun finalize(directory: File, testJar: TestJarImpl? = null) = Unit
+class ElementIdVerifier(
+  predicate: ElementPredicate,
+  elementTable: Array<Element>,
+) {
+  private val notAllowed: IntArray = elementTable.filter(predicate::test).map { it.id }.toIntArray()
+
+  fun isNotAllowed(id: Int) = notAllowed.contains(id)
 }

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/inspect/ElementLookupTable.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/inspect/ElementLookupTable.kt
@@ -17,13 +17,14 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package org.jagrkt.common.export
+package org.jagrkt.common.inspect
 
-import org.jagrkt.common.testing.TestJarImpl
-import java.io.File
+import org.jagrkt.api.inspect.Element
 
-interface Exporter {
-  val name: String
-  fun initialize(directory: File, testJar: TestJarImpl? = null) = Unit
-  fun finalize(directory: File, testJar: TestJarImpl? = null) = Unit
+class ElementLookupTable(
+  val data: Array<Element>,
+) {
+
+
+
 }

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/inspect/ExecutionScopeImpl.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/inspect/ExecutionScopeImpl.kt
@@ -1,0 +1,56 @@
+/*
+ *   JagrKt - JagrKt.org
+ *   Copyright (C) 2021 Alexander Staeding
+ *   Copyright (C) 2021 Contributors
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jagrkt.common.inspect
+
+import org.jagrkt.api.executor.ElementPredicate
+import org.jagrkt.api.executor.ExecutionScope
+import org.jagrkt.api.executor.ExecutionSnapshot
+import org.jagrkt.api.executor.ScopeVerificationException
+import org.jagrkt.api.inspect.Element
+import java.util.ArrayDeque
+import java.util.Deque
+
+data class ExecutionScopeImpl(
+  val elementTable: Array<Element>,
+  val predicate: ElementPredicate,
+) : ExecutionScope {
+
+  private val elementIds: Deque<Int> = ArrayDeque()
+  private val elements: Deque<Element> = ArrayDeque()
+  private val idVerifier = ElementIdVerifier(predicate, elementTable)
+  private lateinit var snapshot: ExecutionSnapshot
+
+  fun pushElement(id: Int) {
+    if (idVerifier.isNotAllowed(id)) {
+      throw ScopeVerificationException()
+    }
+    elementIds += id
+  }
+
+  override fun pushElement(element: Element) {
+    pushElement(element.id)
+    elements += element
+  }
+
+  fun setSnapshot(snapshot: ExecutionSnapshot) {
+    this.snapshot = snapshot
+  }
+  override fun getSnapshot(): ExecutionSnapshot = snapshot
+}

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/rubric/grader/ContextAwareGraderBuilderImpl.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/rubric/grader/ContextAwareGraderBuilderImpl.kt
@@ -1,0 +1,42 @@
+package org.jagrkt.common.rubric.grader
+
+import org.jagrkt.api.rubric.Criterion
+import org.jagrkt.api.rubric.GradeResult
+import org.jagrkt.api.rubric.Grader
+import org.jagrkt.api.rubric.Grader.ContextAwareBuilder
+import org.jagrkt.api.inspect.CodeContext
+import org.jagrkt.api.inspect.ContextResolver
+import org.jagrkt.api.testing.TestCycle
+
+class ContextAwareGraderBuilderImpl<C : CodeContext>(
+  private val contextResolver: ContextResolver<C>,
+) : AbstractGraderBuilder<ContextAwareBuilder<C>>(), ContextAwareBuilder<C> {
+  override fun getThis(): ContextAwareBuilder<C> = this
+
+  private fun ContextAwareBuilder.ContextualPredicate<C>?.expand(): ((TestCycle, Criterion) -> Boolean)? {
+    return if (this == null) null else { t, c -> test(t, c, null) }
+  }
+
+  private fun ContextAwareBuilder.ContextualGrader<C>?.expand(): ((TestCycle, Criterion) -> GradeResult)? {
+    return if (this == null) null else { t, c -> calculate(t, c, null) }
+  }
+
+  override fun requireMatch(contextPredicate: ContextAwareBuilder.ContextualPredicate<C>?): ContextAwareBuilder<C> {
+    predicate = contextPredicate.expand()
+    return this
+  }
+
+  override fun pointsPassed(pointCalculator: ContextAwareBuilder.ContextualGrader<C>?): ContextAwareBuilder<C> {
+    //pointCalculatorPassed = pointCalculator.expand()
+    return this
+  }
+
+  override fun pointsFailed(pointCalculator: ContextAwareBuilder.ContextualGrader<C>?): ContextAwareBuilder<C> {
+    //pointCalculatorFailed = pointCalculator.expand()
+    return this
+  }
+
+  override fun build(): Grader {
+    TODO("Not yet implemented")
+  }
+}

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/rubric/grader/ContextAwareGraderImpl.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/rubric/grader/ContextAwareGraderImpl.kt
@@ -1,0 +1,20 @@
+package org.jagrkt.common.rubric.grader
+
+import org.jagrkt.api.rubric.Criterion
+import org.jagrkt.api.rubric.GradeResult
+import org.jagrkt.api.rubric.Grader
+import org.jagrkt.api.testing.TestCycle
+
+class ContextAwareGraderImpl(
+  private val predicate: ((TestCycle, Criterion) -> Boolean)?,
+  private val pointCalculatorPassed: ((TestCycle, Criterion) -> GradeResult)?,
+  private val pointCalculatorFailed: ((TestCycle, Criterion) -> GradeResult)?,
+) : Grader {
+
+  override fun grade(testCycle: TestCycle, criterion: Criterion): GradeResult? {
+    if (predicate?.invoke(testCycle, criterion) == false) {
+      return null
+    }
+    return null // TODO: Finish implementing this
+  }
+}

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/rubric/grader/GraderFactoryImpl.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/rubric/grader/GraderFactoryImpl.kt
@@ -20,6 +20,8 @@
 package org.jagrkt.common.rubric.grader
 
 import com.google.inject.Inject
+import org.jagrkt.api.inspect.CodeContext
+import org.jagrkt.api.inspect.ContextResolver
 import org.jagrkt.api.rubric.Grader
 import org.slf4j.Logger
 
@@ -27,5 +29,7 @@ class GraderFactoryImpl @Inject constructor(
   private val logger: Logger,
 ) : Grader.Factory {
   override fun testAwareBuilder() = TestAwareGraderBuilderImpl()
+  override fun <C : CodeContext> contextAwareBuilder(resolver: ContextResolver<C>): Grader.ContextAwareBuilder<C> = ContextAwareGraderBuilderImpl(resolver)
   override fun descendingPriority(vararg graders: Grader) = DescendingPriorityGrader(logger, *graders)
+  override fun minIfAllUnchanged(vararg contexts: ContextResolver<*>): Grader = MinIfAllUnchangedGrader(*contexts)
 }

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/rubric/grader/MinIfAllUnchangedGrader.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/rubric/grader/MinIfAllUnchangedGrader.kt
@@ -1,0 +1,21 @@
+package org.jagrkt.common.rubric.grader
+
+import org.jagrkt.api.inspect.ContextResolver
+import org.jagrkt.api.rubric.Criterion
+import org.jagrkt.api.rubric.GradeResult
+import org.jagrkt.api.rubric.Grader
+import org.jagrkt.api.testing.TestCycle
+
+class MinIfAllUnchangedGrader(
+  private vararg val contexts: ContextResolver<*>
+) : Grader {
+
+  override fun grade(testCycle: TestCycle, criterion: Criterion): GradeResult? {
+    /*for (context in contexts) {
+      if (context.exists() || context.modifiedSource != context.originalSource) {
+        return Optional.empty()
+      }
+    }*/
+    return GradeResult.ofMin(criterion)
+  }
+}

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/testing/JavaRuntimeTester.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/testing/JavaRuntimeTester.kt
@@ -36,8 +36,8 @@ class JavaRuntimeTester @Inject constructor(
   private val logger: Logger,
   private val testCycleParameterResolver: TestCycleParameterResolver,
 ) : RuntimeTester {
-  override fun createTestCycle(testJar: TestJar, submission: Submission): TestCycle? {
-    if (submission !is JavaSubmission) return null
+  override fun createTestCycle(testJar: TestJarImpl, submission: Submission): TestCycle? {
+    if (submission !is JavaSubmissionImpl) return null
     val info = submission.info
     val rubricProviders = testJar.rubricProviders[info.assignmentId] ?: return null
     val classLoader = RuntimeClassLoader(submission.compiledClasses + testJar.compiledClasses)

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/testing/JavaSubmissionImpl.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/testing/JavaSubmissionImpl.kt
@@ -17,13 +17,21 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package org.jagrkt.common.export
+package org.jagrkt.common.testing
 
-import org.jagrkt.common.testing.TestJarImpl
-import java.io.File
+import org.jagrkt.api.testing.JavaSubmission
+import org.jagrkt.api.testing.SourceFile
+import org.jagrkt.api.testing.SubmissionInfo
+import org.jagrkt.common.compiler.java.JavaCompileResult
+import spoon.reflect.CtModel
 
-interface Exporter {
-  val name: String
-  fun initialize(directory: File, testJar: TestJarImpl? = null) = Unit
-  fun finalize(directory: File, testJar: TestJarImpl? = null) = Unit
+data class JavaSubmissionImpl(
+  private val info: SubmissionInfo,
+  private val compileResult: JavaCompileResult,
+) : JavaSubmission {
+  val file = compileResult.file
+  override fun getInfo(): SubmissionInfo = info
+  override fun getCompileResult(): JavaCompileResult = compileResult
+  override fun getSourceFile(fileName: String): SourceFile? = compileResult.sourceFiles[fileName]
+  override fun toString(): String = "$info(${file.name})"
 }

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/testing/JavaTestCycle.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/testing/JavaTestCycle.kt
@@ -19,17 +19,20 @@
 
 package org.jagrkt.common.testing
 
+import org.jagrkt.api.executor.ExecutionScopeStack
 import org.jagrkt.api.testing.TestCycle
 
 data class JavaTestCycle(
   private val rubricProviderClassNames: List<String>,
-  private val submission: JavaSubmission,
+  private val submission: JavaSubmissionImpl,
   private val classLoader: ClassLoader,
+  private val executionScopeStack: ExecutionScopeStack,
 ) : TestCycle {
   private var jUnitResult: TestCycle.JUnitResult? = null
+  override fun getExecutionScopes(): ExecutionScopeStack = executionScopeStack
   override fun getRubricProviderClassNames(): List<String> = rubricProviderClassNames
   override fun getClassLoader(): ClassLoader = classLoader
-  override fun getSubmission(): JavaSubmission = submission
+  override fun getSubmission(): JavaSubmissionImpl = submission
   override fun getJUnitResult(): TestCycle.JUnitResult? = jUnitResult
   fun setJUnitResult(jUnitResult: TestCycle.JUnitResult?) {
     this.jUnitResult = jUnitResult

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/testing/ModelBuilder.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/testing/ModelBuilder.kt
@@ -17,13 +17,20 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package org.jagrkt.common.export
+package org.jagrkt.common.testing
 
-import org.jagrkt.common.testing.TestJarImpl
-import java.io.File
+import org.jagrkt.api.testing.JavaCompiledProgram
+import spoon.Launcher
+import spoon.reflect.CtModel
+import spoon.support.compiler.VirtualFile
 
-interface Exporter {
-  val name: String
-  fun initialize(directory: File, testJar: TestJarImpl? = null) = Unit
-  fun finalize(directory: File, testJar: TestJarImpl? = null) = Unit
+lateinit var program: JavaCompiledProgram
+fun JavaSubmissionImpl.buildModel(): CtModel {
+  val launcher = Launcher()
+  for ((_, sourceFile) in compileResult.sourceFiles) {
+    launcher.addInputResource(VirtualFile(sourceFile.content, sourceFile.name))
+  }
+  program.compileResult.otherCount
+  launcher.buildModel()
+  return launcher.model
 }

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/testing/RuntimeGrader.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/testing/RuntimeGrader.kt
@@ -30,7 +30,7 @@ class RuntimeGrader @Inject constructor(
   private val logger: Logger,
   private val testers: Set<RuntimeTester>,
 ) {
-  fun grade(tests: List<TestJar>, submission: Submission): Map<GradedRubric, String> {
+  fun grade(tests: List<TestJarImpl>, submission: Submission): Map<GradedRubric, String> {
     val gradedRubrics: MutableMap<GradedRubric, String> = mutableMapOf()
     for (test in tests) {
       for (tester in testers) {

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/testing/RuntimeTester.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/testing/RuntimeTester.kt
@@ -23,5 +23,5 @@ import org.jagrkt.api.testing.Submission
 import org.jagrkt.api.testing.TestCycle
 
 fun interface RuntimeTester {
-  fun createTestCycle(testJar: TestJar, submission: Submission): TestCycle?
+  fun createTestCycle(testJar: TestJarImpl, submission: Submission): TestCycle?
 }

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/testing/TestJarImpl.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/testing/TestJarImpl.kt
@@ -23,19 +23,23 @@ import com.google.common.base.MoreObjects
 import org.jagrkt.api.rubric.RubricForSubmission
 import org.jagrkt.api.rubric.RubricProvider
 import org.jagrkt.api.rubric.TestForSubmission
+import org.jagrkt.api.testing.CompileResult
+import org.jagrkt.api.testing.JavaCompiledProgram
+import org.jagrkt.api.testing.SourceFile
+import org.jagrkt.api.testing.TestJar
 import org.jagrkt.common.compiler.java.CompiledClass
-import org.jagrkt.common.compiler.java.JavaSourceFile
+import org.jagrkt.common.compiler.java.JavaCompileResult
 import org.jagrkt.common.compiler.java.RuntimeClassLoader
 import org.slf4j.Logger
-import java.io.File
+import spoon.reflect.CtModel
 
-class TestJar(
+class TestJarImpl(
   private val logger: Logger,
-  val file: File,
-  val compiledClasses: Map<String, CompiledClass>,
-  val sourceFiles: Map<String, JavaSourceFile>,
+  private val compileResult: JavaCompileResult,
   solutionClasses: Map<String, CompiledClass>,
-) {
+) : TestJar, JavaCompiledProgram {
+
+  val file = compileResult.file
 
   val name: String = with(file.name) { substring(0, indexOf(".jar")) }
 
@@ -54,6 +58,7 @@ class TestJar(
   init {
     val rubricProviders: MutableMap<String, MutableList<String>> = mutableMapOf()
     val testProviders: MutableMap<String, MutableList<String>> = mutableMapOf()
+    val compiledClasses = compileResult.compiledClasses
     val baseClassLoader = RuntimeClassLoader(compiledClasses + solutionClasses)
     for (className in compiledClasses.keys) {
       val clazz = baseClassLoader.loadClass(className)
@@ -62,6 +67,16 @@ class TestJar(
     }
     this.rubricProviders = rubricProviders
     this.testProviders = testProviders
+  }
+
+  override fun getCompileResult() = compileResult
+
+  override fun getSourceFile(fileName: String?): SourceFile? {
+    TODO("Not yet implemented")
+  }
+
+  override fun getModel(): CtModel {
+    TODO("Not yet implemented")
   }
 
   private fun MutableMap<String, MutableList<String>>.putIfRubric(clazz: Class<*>) {

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/testing/ThreadedGlobalParameterResolver.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/testing/ThreadedGlobalParameterResolver.kt
@@ -41,4 +41,4 @@ sealed class ThreadedGlobalParameterResolver<T : Any>(private val type: KClass<T
 }
 
 @Singleton
-class TestCycleParameterResolver : ThreadedGlobalParameterResolver<TestCycle>(TestCycle::class), TestCycleResolver.Internal
+object TestCycleParameterResolver : ThreadedGlobalParameterResolver<TestCycle>(TestCycle::class), TestCycleResolver.Internal

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/transformer/CommonTransformer.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/transformer/CommonTransformer.kt
@@ -58,6 +58,7 @@ private class CommonMethodVisitor(
   methodVisitor: MethodVisitor,
 ) : MethodVisitor(Opcodes.ASM9, methodVisitor) {
   override fun visitCode() {
+    visitCallStackIsns()
     visitTimeoutIsns()
     super.visitCode()
   }
@@ -65,6 +66,11 @@ private class CommonMethodVisitor(
   override fun visitJumpInsn(opcode: Int, label: Label?) {
     visitTimeoutIsns()
     super.visitJumpInsn(opcode, label)
+  }
+
+  private fun visitCallStackIsns() {
+    if (!config.transformers.callStack.enabled) return
+    visitMethodInsn(Opcodes.INVOKESTATIC, "org/jagrkt/common/executor/ExecutionContextHandler", "checkExecutionContext", "()V", false)
   }
 
   private fun visitTimeoutIsns() {

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/transformer/CommonTransformer.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/transformer/CommonTransformer.kt
@@ -58,7 +58,7 @@ private class CommonMethodVisitor(
   methodVisitor: MethodVisitor,
 ) : MethodVisitor(Opcodes.ASM9, methodVisitor) {
   override fun visitCode() {
-    visitCallStackIsns()
+    visitExecutionContextInsn()
     visitTimeoutIsns()
     super.visitCode()
   }
@@ -68,7 +68,7 @@ private class CommonMethodVisitor(
     super.visitJumpInsn(opcode, label)
   }
 
-  private fun visitCallStackIsns() {
+  private fun visitExecutionContextInsn() {
     if (!config.transformers.callStack.enabled) return
     visitMethodInsn(Opcodes.INVOKESTATIC, "org/jagrkt/common/executor/ExecutionContextHandler", "checkExecutionContext", "()V", false)
   }

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/transformer/TransformerManager.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/transformer/TransformerManager.kt
@@ -21,7 +21,7 @@ package org.jagrkt.common.transformer
 
 import com.google.inject.Inject
 import org.jagrkt.common.compiler.java.CompiledClass
-import org.jagrkt.common.compiler.java.RuntimeJarLoader
+import org.jagrkt.common.compiler.java.JavaCompileResult
 
 class TransformerManager @Inject constructor(
   private val commonTransformer: CommonTransformer,
@@ -34,7 +34,7 @@ class TransformerManager @Inject constructor(
     return this
   }
 
-  fun transform(result: RuntimeJarLoader.CompileJarResult): RuntimeJarLoader.CompileJarResult {
+  fun transform(result: JavaCompileResult): JavaCompileResult {
     return result.copyWith(compiledClasses = result.compiledClasses.toMutableMap().transform())
   }
 }


### PR DESCRIPTION
Adds the ExecutionContext API to be able to verify runtime properties such as the stack trace.

For now, there is one standard verifier available: `ExecutionContextVerifier.ensureNotRecursive()` which ensures that there are no dupliate elements in the stacktrace. This check is injected as an INVOKESTATIC call via ASM into the head of every method in the submission and test jar.