### PR TITLE
Trim input for submission-info.json

### DIFF
--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/SubmissionInfoImpl.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/SubmissionInfoImpl.kt
@@ -88,5 +88,5 @@ data class SourceSetInfo(
 private object TrimmingStringSerializer : KSerializer<String> {
   override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("TrimmingString", PrimitiveKind.STRING)
   override fun deserialize(decoder: Decoder): String = decoder.decodeString().trim()
-  override fun serialize(encoder: Encoder, value: String) = encoder.encodeString(value)
+  override fun serialize(encoder: Encoder, value: String) = encoder.encodeString(value.trim())
 }

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/SubmissionInfoImpl.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/SubmissionInfoImpl.kt
@@ -16,10 +16,18 @@
  *     You should have received a copy of the GNU Affero General Public License
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+@file:UseSerializers(serializerClasses = [TrimmingStringSerializer::class])
 
 package org.sourcegrade.jagr.core.testing
 
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.UseSerializers
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import org.sourcegrade.jagr.api.testing.SubmissionInfo
 import org.sourcegrade.jagr.launcher.io.SerializationScope
 import org.sourcegrade.jagr.launcher.io.SerializerFactory
@@ -75,4 +83,10 @@ data class SourceSetInfo(
       scope.writeList(obj.files)
     }
   }
+}
+
+private object TrimmingStringSerializer : KSerializer<String> {
+  override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("TrimmingString", PrimitiveKind.STRING)
+  override fun deserialize(decoder: Decoder): String = decoder.decodeString().trim()
+  override fun serialize(encoder: Encoder, value: String) = encoder.encodeString(value)
 }


### PR DESCRIPTION
Currently, trailing whitespace in a String field in the `submission-info.json` file will cause a crash later on during the submission export:

```
Exception in thread "main" java.io.FileNotFoundException: submissions-export\FOP-2022-H02-Root-grader-sources\h02_foo_ bar _ baz \src\main\resources\submission-info.json (The system cannot find the path specified)
	at java.base/java.io.FileOutputStream.open0(Native Method)
	at java.base/java.io.FileOutputStream.open(FileOutputStream.java:293)
	at java.base/java.io.FileOutputStream.<init>(FileOutputStream.java:235)
	at java.base/java.io.FileOutputStream.<init>(FileOutputStream.java:184)
	at org.sourcegrade.jagr.launcher.io.ResourceKt.writeIn(Resource.kt:47)
	at org.sourcegrade.jagr.launcher.io.ResourceKt.writeIn$default(Resource.kt:42)
	at org.sourcegrade.jagr.launcher.io.ResourceContainerKt.writeAsDirIn(ResourceContainer.kt:86)
```

Directories may not have trailing whitespace, so this must be filtered early on.

This PR adds a custom trimming serializer for Strings in `SubmissionInfoImpl`.