### PR TITLE
Resource extractors

### DIFF
--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/compiler/MutableResourceCollector.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/compiler/MutableResourceCollector.kt
@@ -1,0 +1,29 @@
+/*
+ *   Jagr - SourceGrade.org
+ *   Copyright (C) 2021 Alexander Staeding
+ *   Copyright (C) 2021 Contributors
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.sourcegrade.jagr.core.compiler
+
+interface MutableResourceCollector : ResourceCollector {
+  /**
+   * Adds a resource to this collector. The provided value's runtime type is the key for the resource.
+   *
+   * The value is then accessible via [get].
+   */
+  fun addResource(value: Any)
+}

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/compiler/ResourceCollector.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/compiler/ResourceCollector.kt
@@ -1,0 +1,36 @@
+/*
+ *   Jagr - SourceGrade.org
+ *   Copyright (C) 2021 Alexander Staeding
+ *   Copyright (C) 2021 Contributors
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.sourcegrade.jagr.core.compiler
+
+import org.sourcegrade.jagr.core.compiler.java.JavaCompileResult
+import org.sourcegrade.jagr.core.testing.SubmissionInfoImpl
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KClass
+
+interface ResourceCollector {
+  operator fun <T : Any> get(type: KClass<T>): T?
+}
+
+inline fun <reified T : Any> ResourceCollector.get() = get(T::class)
+
+val JavaCompileResult.submissionInfo: SubmissionInfoImpl? by collected()
+
+private inline fun <reified T : Any> collected(): ReadOnlyProperty<JavaCompileResult, T?> =
+  ReadOnlyProperty { e, _ -> e.resourceCollector.get() }

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/compiler/ResourceCollectorImpl.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/compiler/ResourceCollectorImpl.kt
@@ -1,0 +1,42 @@
+/*
+ *   Jagr - SourceGrade.org
+ *   Copyright (C) 2021 Alexander Staeding
+ *   Copyright (C) 2021 Contributors
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.sourcegrade.jagr.core.compiler
+
+import org.sourcegrade.jagr.launcher.io.SerializationScope
+import org.sourcegrade.jagr.launcher.io.SerializerFactory
+import org.sourcegrade.jagr.launcher.io.readDynamicMap
+import org.sourcegrade.jagr.launcher.io.writeDynamicMap
+import kotlin.reflect.KClass
+
+data class ResourceCollectorImpl(
+  private val backing: MutableMap<KClass<out Any>, Any> = mutableMapOf(),
+) : MutableResourceCollector {
+
+  override fun addResource(value: Any) {
+    backing[value::class] = value
+  }
+
+  override fun <T : Any> get(type: KClass<T>): T? = backing[type] as T?
+
+  companion object Factory : SerializerFactory<ResourceCollectorImpl> {
+    override fun read(scope: SerializationScope.Input) = ResourceCollectorImpl(scope.readDynamicMap().toMutableMap())
+    override fun write(obj: ResourceCollectorImpl, scope: SerializationScope.Output) = scope.writeDynamicMap(obj.backing)
+  }
+}

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/compiler/ResourceExtractor.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/compiler/ResourceExtractor.kt
@@ -1,0 +1,41 @@
+/*
+ *   Jagr - SourceGrade.org
+ *   Copyright (C) 2021 Alexander Staeding
+ *   Copyright (C) 2021 Contributors
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.sourcegrade.jagr.core.compiler
+
+import org.sourcegrade.jagr.launcher.io.Resource
+import org.sourcegrade.jagr.launcher.io.ResourceContainerInfo
+
+fun interface ResourceExtractor {
+  /**
+   * Attempts to extract a special kind of resource from [resource].
+   */
+  fun extract(
+    containerInfo: ResourceContainerInfo,
+    resource: Resource,
+    data: ByteArray,
+    collector: MutableResourceCollector,
+  )
+}
+
+fun extractorOf(vararg extractors: ResourceExtractor) = ResourceExtractor { containerInfo, resource, data, collector ->
+  for (extractor in extractors) {
+    extractor.extract(containerInfo, resource, data, collector)
+  }
+}

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/compiler/java/JavaCompileResult.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/compiler/java/JavaCompileResult.kt
@@ -21,23 +21,22 @@ package org.sourcegrade.jagr.core.compiler.java
 
 import org.slf4j.Logger
 import org.sourcegrade.jagr.api.testing.CompileResult
-import org.sourcegrade.jagr.core.testing.SubmissionInfoImpl
+import org.sourcegrade.jagr.core.compiler.ResourceCollector
+import org.sourcegrade.jagr.core.compiler.ResourceCollectorImpl
 import org.sourcegrade.jagr.launcher.io.ResourceContainerInfo
 import org.sourcegrade.jagr.launcher.io.SerializationScope
 import org.sourcegrade.jagr.launcher.io.SerializerFactory
 import org.sourcegrade.jagr.launcher.io.read
 import org.sourcegrade.jagr.launcher.io.readList
 import org.sourcegrade.jagr.launcher.io.readMap
-import org.sourcegrade.jagr.launcher.io.readNullable
 import org.sourcegrade.jagr.launcher.io.write
 import org.sourcegrade.jagr.launcher.io.writeList
 import org.sourcegrade.jagr.launcher.io.writeMap
-import org.sourcegrade.jagr.launcher.io.writeNullable
 
 data class JavaCompileResult(
   val container: ResourceContainerInfo,
+  val resourceCollector: ResourceCollector = ResourceCollectorImpl(),
   val runtimeResources: RuntimeResources = RuntimeResources(),
-  val submissionInfo: SubmissionInfoImpl? = null,
   val sourceFiles: Map<String, JavaSourceFile> = mapOf(),
   private val messages: List<String> = listOf(),
   val warnings: Int = 0,
@@ -66,7 +65,7 @@ data class JavaCompileResult(
     override fun read(scope: SerializationScope.Input): JavaCompileResult = JavaCompileResult(
       scope.read(),
       scope.read(),
-      scope.readNullable(),
+      scope.read(),
       scope.readMap(),
       scope.readList(),
       scope.input.readInt(),
@@ -76,8 +75,8 @@ data class JavaCompileResult(
 
     override fun write(obj: JavaCompileResult, scope: SerializationScope.Output) {
       scope.write(obj.container)
+      scope.write(obj.resourceCollector)
       scope.write(obj.runtimeResources)
-      scope.writeNullable(obj.submissionInfo)
       scope.writeMap(obj.sourceFiles)
       scope.writeList(obj.messages)
       scope.output.writeInt(obj.warnings)

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/compiler/java/RuntimeJarLoader.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/compiler/java/RuntimeJarLoader.kt
@@ -67,8 +67,8 @@ class RuntimeJarLoader @Inject constructor(
     resourceExtractor: ResourceExtractor = ResourceExtractor { _, _, _, _ -> },
   ): JavaCompileResult {
     val resourceCollector = ResourceCollectorImpl()
-    val sourceFiles: MutableMap<String, JavaSourceFile> = mutableMapOf()
-    val resources = runtimeResources.resources.toMutableMap()
+    val sourceFiles = mutableMapOf<String, JavaSourceFile>()
+    val resources = mutableMapOf<String, ByteArray>()
     for (resource in container) {
       when {
         resource.name.endsWith(".java") -> {

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/executor/GradingQueueImpl.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/executor/GradingQueueImpl.kt
@@ -24,12 +24,15 @@ import kotlinx.coroutines.sync.withLock
 import org.slf4j.Logger
 import org.sourcegrade.jagr.api.testing.ClassTransformer
 import org.sourcegrade.jagr.api.testing.Submission
+import org.sourcegrade.jagr.core.compiler.extractorOf
 import org.sourcegrade.jagr.core.compiler.java.RuntimeJarLoader
 import org.sourcegrade.jagr.core.compiler.java.compile
 import org.sourcegrade.jagr.core.compiler.java.loadCompiled
 import org.sourcegrade.jagr.core.compiler.java.plus
+import org.sourcegrade.jagr.core.compiler.submissionInfo
 import org.sourcegrade.jagr.core.testing.GraderJarImpl
 import org.sourcegrade.jagr.core.testing.JavaSubmission
+import org.sourcegrade.jagr.core.testing.SubmissionInfoImpl
 import org.sourcegrade.jagr.core.transformer.SubmissionVerificationTransformer
 import org.sourcegrade.jagr.core.transformer.applierOf
 import org.sourcegrade.jagr.core.transformer.plus
@@ -82,8 +85,10 @@ class GradingQueueImpl(
   }.fold(baseSubmissionTransformerApplier) { a, b -> a + b }
 
   override val submissions: List<Submission> = batch.submissions.compile(
-    logger, submissionTransformerApplier, runtimeJarLoader, baseRuntimeLibraries, "submission"
+    logger, submissionTransformerApplier, runtimeJarLoader, baseRuntimeLibraries, "submission",
+    extractorOf(SubmissionInfoImpl.Extractor),
   ) {
+    val submissionInfo = this.submissionInfo
     if (submissionInfo == null) {
       logger.error("${container.name} does not have a submission-info.json! Skipping...")
       return@compile null

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/io/SerializationFactoryLocatorImpl.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/io/SerializationFactoryLocatorImpl.kt
@@ -27,6 +27,8 @@ import org.sourcegrade.jagr.api.rubric.Rubric
 import org.sourcegrade.jagr.api.testing.Submission
 import org.sourcegrade.jagr.api.testing.SubmissionInfo
 import org.sourcegrade.jagr.api.testing.TestCycle
+import org.sourcegrade.jagr.core.compiler.ResourceCollector
+import org.sourcegrade.jagr.core.compiler.ResourceCollectorImpl
 import org.sourcegrade.jagr.core.executor.GradingRequestImpl
 import org.sourcegrade.jagr.core.rubric.CriterionImpl
 import org.sourcegrade.jagr.core.rubric.GradeResultImpl
@@ -51,6 +53,7 @@ class SerializationFactoryLocatorImpl : SerializerFactory.Locator {
     GradedRubric::class -> GradedRubricImpl
     GraderJar::class -> GraderJarImpl
     GradingRequest::class -> GradingRequestImpl
+    ResourceCollector::class -> ResourceCollectorImpl
     Submission::class -> JavaSubmission
     SubmissionInfo::class -> SubmissionInfoImpl
     TestCycle::class -> JavaTestCycle


### PR DESCRIPTION
Adds the `ResourceExtractor` system which may be used to load special kinds of resources from `ResourceContainers`.

An example of such a resource is the `submission-info.json`. This is currently handled separately here:
https://github.com/SourceGrade/Jagr/blob/f2ae57ad4ffeeddebb2b376c1ad573fd097915f5/core/src/main/kotlin/org/sourcegrade/jagr/core/compiler/java/RuntimeJarLoader.kt#L64-L73

Unfortunately, while this is sufficient for one kind of "special" resource, it does not scale well as every additional case must be hardcoded in the `RuntimeJarLoader`.

This PR adds an internal (for now) API for handling these cases in a scalable manner. An instance of `ResourceExtractor` may be passed to the jar loading methods. This instance is notified when a resource (i.e. non-class file) is detected in a jar:

https://github.com/SourceGrade/Jagr/blob/71cf2e76e4f09a841fab99144ea99817c7fba9ad/core/src/main/kotlin/org/sourcegrade/jagr/core/compiler/java/RuntimeJarLoader.kt#L82-L83

The `ResourceExtractor` receives, in addition to information about the `Resource`, a `MutableResourceCollector` with a method for adding a resource.

The `ResourceExtractor` is free to (and probably should) convert the provided resource to another type. For example, the `SubmissionInfoImpl.Extractor` attempts to convert any file with the name `submission-info.json` to an instance of `SubmissioninfoImpl` (this replaces the old when-case):
https://github.com/SourceGrade/Jagr/blob/71cf2e76e4f09a841fab99144ea99817c7fba9ad/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/SubmissionInfoImpl.kt#L82-L98
