### PR TITLE
Add getClassNames() to Submission

### DIFF
--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/JavaSubmission.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/JavaSubmission.kt
@@ -40,7 +40,7 @@ data class JavaSubmission(
     override fun getInfo(): SubmissionInfo = info
     override fun getCompileResult(): JavaCompiledContainer = compileResult
     override fun getSourceFile(fileName: String): SourceFile? = compileResult.source.sourceFiles[fileName]
-    override fun getClassNames(): Set<String> = Collections.unmodifiableSet(compileResult.runtimeResources.resources.keys)
+    override fun getClassNames(): Set<String> = Collections.unmodifiableSet(compileResult.runtimeResources.classes.keys)
 
     override fun toString(): String = "$info(${compileResult.info.name})"
 

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/JavaSubmission.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/JavaSubmission.kt
@@ -30,6 +30,7 @@ import org.sourcegrade.jagr.launcher.io.read
 import org.sourcegrade.jagr.launcher.io.readScoped
 import org.sourcegrade.jagr.launcher.io.write
 import org.sourcegrade.jagr.launcher.io.writeScoped
+import java.util.Collections
 
 data class JavaSubmission(
     private val info: SubmissionInfo,
@@ -39,6 +40,8 @@ data class JavaSubmission(
     override fun getInfo(): SubmissionInfo = info
     override fun getCompileResult(): JavaCompiledContainer = compileResult
     override fun getSourceFile(fileName: String): SourceFile? = compileResult.source.sourceFiles[fileName]
+    override fun getClassNames(): Set<String> = Collections.unmodifiableSet(compileResult.runtimeResources.resources.keys)
+
     override fun toString(): String = "$info(${compileResult.info.name})"
 
     companion object Factory : SerializerFactory<JavaSubmission> {

--- a/grader-api/src/main/java/org/sourcegrade/jagr/api/testing/Submission.java
+++ b/grader-api/src/main/java/org/sourcegrade/jagr/api/testing/Submission.java
@@ -22,6 +22,8 @@ package org.sourcegrade.jagr.api.testing;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Set;
+
 @ApiStatus.NonExtendable
 public interface Submission {
 
@@ -30,4 +32,12 @@ public interface Submission {
     CompileResult getCompileResult();
 
     @Nullable SourceFile getSourceFile(String fileName);
+
+    /**
+     * <b>Experimental API. May be moved in a future release.</b>
+     *
+     * @return An immutable set of Java class names from this submission.
+     */
+    @ApiStatus.Experimental
+    Set<String> getClassNames();
 }


### PR DESCRIPTION
Adds an experimental API to `Submission` to get all class names from the given submission. This change is the non-breaking and simpler version of #30 until a (probably breaking) rework of the `testing` package is done.