### PR TITLE
Add concept of trueMaxPoints and trueMinPoints

### DIFF
--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/export/rubric/MoodleJSONExporter.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/export/rubric/MoodleJSONExporter.kt
@@ -38,7 +38,7 @@ class MoodleJSONExporter @Inject constructor(
     override fun export(gradedRubric: GradedRubric): Resource {
         val json = MoodleJSON(
             gradedRubric.testCycle.submission.info as SubmissionInfoImpl,
-            max(0, gradedRubric.rubric.minPoints + gradedRubric.grade.correctPoints),
+            max(0, gradedRubric.rubric.trueMinPoints + gradedRubric.grade.correctPoints),
             StringBuilder().writeTable(gradedRubric).toString(),
         )
         val jsonString = Json.encodeToString(json)

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/export/rubric/RubricExport.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/export/rubric/RubricExport.kt
@@ -30,11 +30,11 @@ val Criterion.minMax: String
 
 fun GradeResult.getInRange(gradable: Gradable<*>): String {
     val minReachedPoints = if (gradable is Rubric) {
-        max(0, gradable.minPoints + correctPoints)
+        max(gradable.minPoints, gradable.trueMinPoints + correctPoints)
     } else {
-        gradable.minPoints + correctPoints
+        gradable.trueMinPoints + correctPoints
     }
-    val maxReachedPoints = max(minReachedPoints, gradable.maxPoints - incorrectPoints)
+    val maxReachedPoints = max(minReachedPoints, gradable.trueMaxPoints - incorrectPoints)
     return if (minReachedPoints == maxReachedPoints) {
         minReachedPoints.toString()
     } else {

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/rubric/CriterionBuilderImpl.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/rubric/CriterionBuilderImpl.kt
@@ -68,8 +68,8 @@ class CriterionBuilderImpl : Criterion.Builder {
             requireNotNull(shortDescription) { "shortDescription is null" },
             hiddenNotes,
             grader,
-            maxCalculator ?: CriterionHolderPointCalculator.maxOfChildren(1),
-            minCalculator ?: CriterionHolderPointCalculator.minOfChildren(0),
+            maxCalculator,
+            minCalculator,
             children,
         )
     }

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/rubric/CriterionHolderPointCalculatorFactoryImpl.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/rubric/CriterionHolderPointCalculatorFactoryImpl.kt
@@ -28,14 +28,14 @@ class CriterionHolderPointCalculatorFactoryImpl : CriterionHolderPointCalculator
 
     override fun maxOfChildren(defaultPoints: Int): CriterionHolderPointCalculator {
         return CriterionHolderPointCalculator {
-            it.childCriteria.asSequence().map(Criterion::getMaxPoints)
+            it.childCriteria.asSequence().map(Criterion::getTrueMaxPoints)
                 .ifEmpty { listOf(defaultPoints).asSequence() }.sum()
         }
     }
 
     override fun minOfChildren(defaultPoints: Int): CriterionHolderPointCalculator {
         return CriterionHolderPointCalculator {
-            it.childCriteria.asSequence().map(Criterion::getMinPoints)
+            it.childCriteria.asSequence().map(Criterion::getTrueMinPoints)
                 .ifEmpty { listOf(defaultPoints).asSequence() }.sum()
         }
     }

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/rubric/CriterionImpl.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/rubric/CriterionImpl.kt
@@ -47,8 +47,8 @@ class CriterionImpl(
     private val shortDescription: String,
     private val hiddenNotes: String?,
     private val grader: Grader?,
-    private val maxCalculator: CriterionHolderPointCalculator,
-    private val minCalculator: CriterionHolderPointCalculator,
+    private val maxCalculator: CriterionHolderPointCalculator?,
+    private val minCalculator: CriterionHolderPointCalculator?,
     private val childCriteria: List<CriterionImpl>,
 ) : Criterion {
 
@@ -58,9 +58,15 @@ class CriterionImpl(
         }
     }
 
+    private fun maxOfChildren(): Int = CriterionHolderPointCalculator.maxOfChildren(1).getPoints(this)
+    private fun minOfChildren(): Int = CriterionHolderPointCalculator.minOfChildren(0).getPoints(this)
+
     private val terminal: Boolean by lazy { childCriteria.isEmpty() }
-    private val maxPointsKt: Int by lazy { maxCalculator.getPoints(this) }
-    private val minPointsKt: Int by lazy { minCalculator.getPoints(this) }
+    private val maxPointsKt: Int by lazy { maxCalculator?.getPoints(this) ?: maxOfChildren() }
+    private val minPointsKt: Int by lazy { minCalculator?.getPoints(this) ?: minOfChildren() }
+    private val trueMaxPointsKt: Int by lazy { maxPointsKt.takeIf { terminal } ?: maxOfChildren() }
+    private val trueMinPointsKt: Int by lazy { minPointsKt.takeIf { terminal } ?: minOfChildren() }
+
     private lateinit var parentKt: CriterionHolder<CriterionImpl>
     private val parentRubricKt: RubricImpl by lazy {
         var current: Criterion = this
@@ -81,6 +87,8 @@ class CriterionImpl(
     override fun isTerminal(): Boolean = terminal
     override fun getMaxPoints(): Int = maxPointsKt
     override fun getMinPoints(): Int = minPointsKt
+    override fun getTrueMaxPoints(): Int = trueMaxPointsKt
+    override fun getTrueMinPoints(): Int = trueMinPointsKt
     override fun getParentRubric(): RubricImpl = parentRubricKt
     override fun getParent(): CriterionHolder<CriterionImpl> = parentKt
     override fun getParentCriterion(): Criterion? = parentCriterionKt

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/rubric/GradeResultFactoryImpl.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/rubric/GradeResultFactoryImpl.kt
@@ -44,8 +44,8 @@ class GradeResultFactoryImpl : GradeResult.Factory {
         return GradeResultImpl(correctPoints, incorrectPoints)
     }
 
-    override fun ofMax(criterion: Criterion): GradeResult = ofCorrect(criterion.maxPoints - criterion.minPoints)
-    override fun ofMin(criterion: Criterion): GradeResult = ofIncorrect(criterion.maxPoints - criterion.minPoints)
+    override fun ofMax(criterion: Criterion): GradeResult = ofCorrect(criterion.trueMaxPoints - criterion.trueMinPoints)
+    override fun ofMin(criterion: Criterion): GradeResult = ofIncorrect(criterion.trueMaxPoints - criterion.trueMinPoints)
 
     override fun withComments(grade: GradeResult, comments: Iterable<String>): GradeResult {
         return GradeResultImpl(grade.correctPoints, grade.incorrectPoints, grade.comments + comments)

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/rubric/RubricImpl.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/rubric/RubricImpl.kt
@@ -48,6 +48,8 @@ class RubricImpl(
     override fun getTitle(): String = title
     override fun getMaxPoints(): Int = maxPointsKt
     override fun getMinPoints(): Int = minPointsKt
+    override fun getTrueMaxPoints(): Int = maxPointsKt
+    override fun getTrueMinPoints(): Int = minPointsKt
     override fun getChildCriteria(): List<CriterionImpl> = criteria
 
     override fun grade(testCycle: TestCycle): GradedRubric {

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/rubric/grader/DescendingPriorityGrader.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/rubric/grader/DescendingPriorityGrader.kt
@@ -39,10 +39,10 @@ class DescendingPriorityGrader(
         if (graders.size == 1) {
             return graders[0].grade(testCycle, criterion)
         }
-        val maxPoints = criterion.maxPoints
+        val maxPoints = criterion.trueMaxPoints
         // negation is on purpose
-        // criterion.minPoints is always negative but it needs to be positive for comparison later
-        val minPoints = -criterion.minPoints
+        // criterion.minPoints is always negative, but it needs to be positive for comparison later
+        val minPoints = -criterion.trueMinPoints
         var correctPoints = 0
         var incorrectPoints = 0
         val comments: MutableList<String> = mutableListOf()

--- a/grader-api/src/main/java/org/sourcegrade/jagr/api/rubric/Gradable.java
+++ b/grader-api/src/main/java/org/sourcegrade/jagr/api/rubric/Gradable.java
@@ -35,6 +35,32 @@ public interface Gradable<G extends Graded> {
     int getMinPoints();
 
     /**
+     * The true maximum number of points is used to calculate the final grade and is not always equal to {@link #getMaxPoints()}.
+     *
+     * <p>
+     * If the maximum number of points is based on other entities (as may be the case in a {@link CriterionHolder}), this
+     * method will always return the sum of the true maximum points of all children. Otherwise, if the maximum number of points
+     * is <strong>not</strong> based on other entities, this will return the same value as {@link #getMaxPoints()}.
+     * </p>
+     *
+     * @return The true maximum number of points
+     */
+    int getTrueMaxPoints();
+
+    /**
+     * The true minimum number of points is used to calculate the final grade and is not always equal to {@link #getMaxPoints()}.
+     *
+     * <p>
+     * If the minimum number of points is based on other entities (as may be the case in a {@link CriterionHolder}), this
+     * method will always return the sum of the true minimum points of all children. Otherwise, if the minimum number of points
+     * is <strong>not</strong> based on other entities, this will return the same value as {@link #getMaxPoints()}.
+     * </p>
+     *
+     * @return The true minimum number of points
+     */
+    int getTrueMinPoints();
+
+    /**
      * Grade the provided {@link TestCycle}
      */
     G grade(TestCycle testCycle);


### PR DESCRIPTION
Currently, overriding `maxPoints` or `minPoints` for a `Criterion` with children breaks the final point calculation because it assumes that the total `minPoints` for a `Rubric` is the sum of all `minPoints`.

If `minPoints` is manually set higher than the "actual" value (the sum of the children's `minPoints`), the difference is added onto the final point calculation.