### PR TITLE
Handle exceptions in RuntimeGrader gracefully

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,6 @@ plugins {
 
 dependencies {
     runtimeOnly(project("jagr-core"))
-    runtimeOnly("fr.inria.gforge.spoon:spoon-core:10.0.0")
     implementation(project("jagr-launcher"))
     implementation("com.github.ajalt.clikt:clikt:3.3.0")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
 
 dependencies {
     runtimeOnly(project("jagr-core"))
+    runtimeOnly("fr.inria.gforge.spoon:spoon-core:10.0.0")
     implementation(project("jagr-launcher"))
     implementation("com.github.ajalt.clikt:clikt:3.3.0")
 }

--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/Executor.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/Executor.kt
@@ -19,12 +19,7 @@
 
 package org.sourcegrade.jagr.launcher.executor
 
-import org.sourcegrade.jagr.api.rubric.GradedRubric
-import org.sourcegrade.jagr.api.testing.Submission
 import org.sourcegrade.jagr.launcher.env.Jagr
-import org.sourcegrade.jagr.launcher.io.GraderJar
-import java.time.OffsetDateTime
-import java.time.ZoneOffset
 
 interface Executor {
     suspend fun schedule(queue: GradingQueue)
@@ -32,19 +27,4 @@ interface Executor {
     interface Factory {
         fun create(jagr: Jagr): Executor
     }
-}
-
-interface RuntimeGrader {
-    fun grade(graders: List<GraderJar>, submission: Submission): Map<GradedRubric, String>
-
-    fun gradeFallback(graders: List<GraderJar>, submission: Submission): Map<GradedRubric, String>
-}
-
-fun RuntimeGrader.grade(job: GradingJob) {
-    val startedUtc = OffsetDateTime.now(ZoneOffset.UTC).toInstant()
-    val rubrics = with(job.request) {
-        grade(graders, submission)
-    }
-    val finishedUtc = OffsetDateTime.now(ZoneOffset.UTC).toInstant()
-    job.result.complete(GradingResult(startedUtc, finishedUtc, job.request, rubrics))
 }

--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/ProcessWorker.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/ProcessWorker.kt
@@ -36,14 +36,10 @@ import org.sourcegrade.jagr.launcher.io.openScope
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.nio.charset.StandardCharsets
-import java.time.Instant
-import java.time.OffsetDateTime
-import java.time.ZoneOffset
 import kotlin.reflect.KFunction1
 
 class ProcessWorker(
     private val jagr: Jagr,
-    private val runtimeGrader: RuntimeGrader,
     private val removeActive: (Worker) -> Unit,
     processIODispatcher: CoroutineDispatcher,
 ) : Worker {
@@ -68,11 +64,8 @@ class ProcessWorker(
         status = WorkerStatus.RUNNING
         coroutineScope.launch {
             sendRequest(job.request)
-            try {
-                job.result.complete(receiveResult(job))
-            } catch (e: Exception) {
-                job.result.completeExceptionally(e)
-            }
+            jagr.logger.info("Sending request!")
+            job.gradeCatching(jagr, ::receiveResult)
             status = WorkerStatus.FINISHED
             removeActive(this@ProcessWorker)
         }
@@ -98,16 +91,15 @@ class ProcessWorker(
         process.outputStream.close()
     }
 
-    private fun receiveResult(job: GradingJob): GradingResult {
-        val startedUtc = OffsetDateTime.now(ZoneOffset.UTC).toInstant()
+    private fun receiveResult(request: GradingRequest): GradingResult? {
         val childProcessIn = process.inputStream
         while (true) {
             val next = childProcessIn.read()
             if (next == MARK_RESULT_BYTE) {
                 break
             } else if (next == -1) {
-                jagr.logger.error("${job.request.submission.info} :: Received unexpected EOF while waiting for child process to complete")
-                return createFallbackResult(startedUtc, job.request)
+                jagr.logger.error("${request.submission.info} :: Received unexpected EOF while waiting for child process to complete")
+                return null
             } else if (next == MARK_LOG_MESSAGE_BYTE) {
                 val level = childProcessIn.read()
                 val length = childProcessIn.read() shl 24 or
@@ -115,12 +107,12 @@ class ProcessWorker(
                     childProcessIn.read() shl 8 or
                     childProcessIn.read()
                 if (length < 0) {
-                    jagr.logger.error("${job.request.submission.info} :: Received IOException while waiting for child process to complete")
-                    return createFallbackResult(startedUtc, job.request)
+                    jagr.logger.error("${request.submission.info} :: Received IOException while waiting for child process to complete")
+                    return null
                 }
                 val message: String = runCatching { process.inputStream.readNBytes(length) }.getOrElse {
-                    jagr.logger.error("${job.request.submission.info} :: Received IOException while waiting for child process to complete")
-                    return createFallbackResult(startedUtc, job.request)
+                    jagr.logger.error("${request.submission.info} :: Received IOException while waiting for child process to complete")
+                    return null
                 }.toString(StandardCharsets.UTF_8)
                 jagr.logger.let<Logger, KFunction1<String, Unit>> {
                     when (level) {
@@ -135,19 +127,13 @@ class ProcessWorker(
             }
         }
         val bytes: ByteArray = runCatching { process.inputStream.readAllBytes() }.getOrElse {
-            jagr.logger.error("${job.request.submission.info} :: Received IOException while waiting for child process to complete")
-            return createFallbackResult(startedUtc, job.request)
+            jagr.logger.error("${request.submission.info} :: Received IOException while waiting for child process to complete")
+            return null
         }
         return openScope(ByteStreams.newDataInput(bytes), jagr) {
-            SerializerFactory.getScoped<GradingRequest>(jagr).putInScope(job.request, this)
+            SerializerFactory.getScoped<GradingRequest>(jagr).putInScope(request, this)
             SerializerFactory.get<GradingResult>(jagr).read(this)
         }
-    }
-
-    private fun createFallbackResult(startedUtc: Instant, request: GradingRequest): GradingResult {
-        val finishedUtc = OffsetDateTime.now(ZoneOffset.UTC).toInstant()
-        val fallbackRubrics = runtimeGrader.gradeFallback(request.graders, request.submission)
-        return GradingResult(startedUtc, finishedUtc, request, fallbackRubrics)
     }
 
     companion object {

--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/ProcessWorker.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/ProcessWorker.kt
@@ -64,7 +64,6 @@ class ProcessWorker(
         status = WorkerStatus.RUNNING
         coroutineScope.launch {
             sendRequest(job.request)
-            jagr.logger.info("Sending request!")
             job.gradeCatching(jagr, ::receiveResult)
             status = WorkerStatus.FINISHED
             removeActive(this@ProcessWorker)

--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/ProcessWorkerPool.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/ProcessWorkerPool.kt
@@ -21,7 +21,6 @@ package org.sourcegrade.jagr.launcher.executor
 
 import kotlinx.coroutines.asCoroutineDispatcher
 import org.sourcegrade.jagr.launcher.env.Jagr
-import org.sourcegrade.jagr.launcher.env.runtimeGrader
 import java.util.concurrent.Executors
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
@@ -56,7 +55,7 @@ class ProcessWorkerPool(
         if (maxCount == 0) return emptyList()
         val workerCount = minOf(maxCount, concurrency - activeWorkers.size)
         return List(workerCount) {
-            ProcessWorker(jagr, jagr.runtimeGrader, this::removeActiveWorker, processIODispatcher).also(activeWorkers::add)
+            ProcessWorker(jagr, this::removeActiveWorker, processIODispatcher).also(activeWorkers::add)
         }
     }
 

--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/RuntimeGrader.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/RuntimeGrader.kt
@@ -1,0 +1,86 @@
+/*
+ *   Jagr - SourceGrade.org
+ *   Copyright (C) 2021 Alexander Staeding
+ *   Copyright (C) 2021 Contributors
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.sourcegrade.jagr.launcher.executor
+
+import org.sourcegrade.jagr.api.rubric.GradedRubric
+import org.sourcegrade.jagr.api.testing.Submission
+import org.sourcegrade.jagr.launcher.env.Jagr
+import org.sourcegrade.jagr.launcher.env.logger
+import org.sourcegrade.jagr.launcher.env.runtimeGrader
+import org.sourcegrade.jagr.launcher.io.GraderJar
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+interface RuntimeGrader {
+    fun grade(graders: List<GraderJar>, submission: Submission): Map<GradedRubric, String>
+
+    fun gradeFallback(graders: List<GraderJar>, submission: Submission): Map<GradedRubric, String>
+}
+
+fun GradingRequest.grade(gradingFun: (List<GraderJar>, Submission) -> Map<GradedRubric, String>): GradingResult {
+    val startedUtc = OffsetDateTime.now(ZoneOffset.UTC).toInstant()
+    val rubrics = gradingFun(graders, submission)
+    val finishedUtc = OffsetDateTime.now(ZoneOffset.UTC).toInstant()
+    return GradingResult(startedUtc, finishedUtc, this, rubrics)
+}
+
+fun GradingRequest.gradeCatching(
+    jagr: Jagr,
+    gradingFun: (List<GraderJar>, Submission) -> Map<GradedRubric, String>,
+): GradingResult? {
+    return try {
+        grade(gradingFun)
+    } catch (e: Throwable) {
+        // catch throwable, we want to complete this job in any circumstance to not block the pipeline for other submissions
+        jagr.logger.error("A fatal error occurred grading ${submission.info} :: ${e::class.simpleName} ${e.message}", e)
+        null
+    }
+}
+
+/**
+ * Attempts to grade this [GradingJob] first with [primaryGrader].
+ * If this fails (i.e. it returns null) grade with the fallback.
+ */
+fun GradingJob.gradeCatching(
+    jagr: Jagr,
+    primaryGrader: (GradingRequest) -> GradingResult? = { request.gradeCatching(jagr, jagr.runtimeGrader::grade) },
+) {
+    jagr.logger.info("gradeCatching!")
+    try {
+        // first try to grade normally, then try to grade with fallback
+        val gradingResult = primaryGrader(request)
+            ?: request.grade(jagr.runtimeGrader::gradeFallback)
+        result.complete(gradingResult)
+    } catch (e: Throwable) {
+        // this should never happen; the fallback grader is only meant to create a minimum rubric
+        // (without running external code) and shouldn't throw anything
+        val causeSTE = e.stackTrace.firstOrNull { !it.className.startsWith("java") }
+        val causeClass = causeSTE?.className
+        val exception = IllegalStateException(
+            """
+A fatal error occurred in the fallback grader for submission ${request.submission.info} :: ${e::class.simpleName} ${e.message}
+This is not an error in the submission, rather in the RuntimeGrader implementation @ $causeSTE.
+Please report this to the maintainers of $causeClass.
+""",
+            e
+        )
+        result.completeExceptionally(exception)
+    }
+}

--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/RuntimeGrader.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/RuntimeGrader.kt
@@ -62,7 +62,6 @@ fun GradingJob.gradeCatching(
     jagr: Jagr,
     primaryGrader: (GradingRequest) -> GradingResult? = { request.gradeCatching(jagr, jagr.runtimeGrader::grade) },
 ) {
-    jagr.logger.info("gradeCatching!")
     try {
         // first try to grade normally, then try to grade with fallback
         val gradingResult = primaryGrader(request)

--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/SyncExecutor.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/SyncExecutor.kt
@@ -22,13 +22,11 @@ package org.sourcegrade.jagr.launcher.executor
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.sourcegrade.jagr.launcher.env.Jagr
-import org.sourcegrade.jagr.launcher.env.runtimeGrader
 
 class SyncExecutor constructor(
-    jagr: Jagr,
+    private val jagr: Jagr,
 ) : Executor {
     private val mutex = Mutex()
-    private val runtimeGrader = jagr.runtimeGrader
     private val scheduled = mutableListOf<GradingQueue>()
 
     override suspend fun schedule(queue: GradingQueue) = mutex.withLock {
@@ -38,7 +36,7 @@ class SyncExecutor constructor(
     override suspend fun start(rubricCollector: MutableRubricCollector) = mutex.withLock {
         while (scheduled.isNotEmpty()) {
             val next = scheduled.next() ?: break
-            runtimeGrader.grade(rubricCollector.start(next))
+            rubricCollector.start(next).gradeCatching(jagr)
         }
         scheduled.clear()
     }

--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/ThreadWorker.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/ThreadWorker.kt
@@ -20,10 +20,11 @@
 package org.sourcegrade.jagr.launcher.executor
 
 import kotlinx.coroutines.runBlocking
+import org.sourcegrade.jagr.launcher.env.Jagr
 import kotlin.concurrent.thread
 
 class ThreadWorker(
-    private val runtimeGrader: RuntimeGrader,
+    private val jagr: Jagr,
     private val removeActive: (Worker) -> Unit,
 ) : Worker {
     override var job: GradingJob? = null
@@ -42,7 +43,7 @@ class ThreadWorker(
             priority = 3,
         ) {
             runBlocking {
-                runtimeGrader.grade(job)
+                job.gradeCatching(jagr)
             }
             status = WorkerStatus.FINISHED
             removeActive(this)

--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/ThreadWorkerPool.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/ThreadWorkerPool.kt
@@ -20,7 +20,6 @@
 package org.sourcegrade.jagr.launcher.executor
 
 import org.sourcegrade.jagr.launcher.env.Jagr
-import org.sourcegrade.jagr.launcher.env.runtimeGrader
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 import kotlin.coroutines.resume
@@ -49,7 +48,7 @@ class ThreadWorkerPool(
         if (maxCount == 0) return emptyList()
         val workerCount = minOf(maxCount, concurrency - activeWorkers.size)
         return List(workerCount) {
-            ThreadWorker(jagr.runtimeGrader, this::removeActiveWorker).also(activeWorkers::add)
+            ThreadWorker(jagr, this::removeActiveWorker).also(activeWorkers::add)
         }
     }
 

--- a/src/main/kotlin/org/sourcegrade/jagr/ChildProcGrading.kt
+++ b/src/main/kotlin/org/sourcegrade/jagr/ChildProcGrading.kt
@@ -66,14 +66,17 @@ class ChildProcGrading(private val jagr: Jagr = Jagr) {
     }
 
     private fun notifyParent(collector: RubricCollector) {
+        collector.gradingFinished.firstOrNull()?.sendToParent()
+        Environment.stdOut.close()
+    }
+
+    private fun GradingResult.sendToParent() {
         val outputStream = ByteArrayOutputStream(8192)
         val output = ByteStreams.newDataOutput(outputStream)
         Environment.stdOut.write(ProcessWorker.MARK_RESULT_BYTE)
-        val before = collector.gradingFinished[0]
         openScope(output, Jagr) {
-            SerializerFactory.get<GradingResult>().write(before, this)
+            SerializerFactory.get<GradingResult>().write(this@sendToParent, this)
         }
         outputStream.writeTo(Environment.stdOut)
-        Environment.stdOut.close()
     }
 }


### PR DESCRIPTION
Currently, exceptions thrown in either `RuntimeGrader.grade` or `RuntimeGrader.gradeFallback` cause the grading process to hang  because `job.result.complete` never executes (because of the exception thrown during `grade` on line 46.

https://github.com/SourceGrade/Jagr/blob/802f68ff6799dc5793a7ddebb5c8bb1783e40683/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/Executor.kt#L43-L49

This causes the executor to believe the job was never completed.

This PR moves `RuntimeGrader` to a separate file and adds a few methods that handle exceptions properly.
