### PR TITLE
Add --no-export flag

### DIFF
--- a/src/main/kotlin/org/sourcegrade/jagr/Main.kt
+++ b/src/main/kotlin/org/sourcegrade/jagr/Main.kt
@@ -42,6 +42,7 @@ class MainCommand : CliktCommand() {
      * Command line option to indicate that this process will listen to (via std in) to a grading request
      */
     private val child by option("--child", "-c").flag()
+    private val noExport by option("--no-export", "-n").flag()
     private val exportOnly by option("--export-only", "-e").flag()
     private val progress by option("--progress").choice("rainbow", "xmas")
     override fun run() {
@@ -51,7 +52,7 @@ class MainCommand : CliktCommand() {
         } else {
             Environment.initializeMainProcess()
             val startTime = System.currentTimeMillis()
-            StandardGrading(progress).grade(exportOnly)
+            StandardGrading(progress).grade(noExport, exportOnly)
             Jagr.logger.info("Time taken: ${System.currentTimeMillis() - startTime}")
         }
     }

--- a/src/main/kotlin/org/sourcegrade/jagr/StandardGrading.kt
+++ b/src/main/kotlin/org/sourcegrade/jagr/StandardGrading.kt
@@ -67,7 +67,8 @@ class StandardGrading(
         val queue = jagr.gradingQueueFactory.create(batch)
         if (!noExport) {
             exportSubmissions(queue)
-        } else if (exportOnly) {
+        }
+        if (exportOnly) {
             jagr.logger.info("Only exporting, finished!")
             return@runBlocking
         }


### PR DESCRIPTION
Adds a command-line `--no-export` flag that skips the submissions-export