### PR TITLE
Add default method ClassTransformer.getWriterFlags()

### DIFF
--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/transformer/TransformerApplier.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/transformer/TransformerApplier.kt
@@ -80,7 +80,7 @@ fun Map<String, CompiledClass>.transform(transformer: ClassTransformer): Map<Str
 
 fun ClassTransformer.transform(byteArray: ByteArray): ByteArray {
     val reader = ClassReader(byteArray)
-    val writer = ClassWriter(reader, 0)
+    val writer = ClassWriter(reader, writerFlags)
     transform(reader, writer)
     return writer.toByteArray()
 }

--- a/grader-api/src/main/java/org/sourcegrade/jagr/api/testing/ClassTransformer.java
+++ b/grader-api/src/main/java/org/sourcegrade/jagr/api/testing/ClassTransformer.java
@@ -34,6 +34,16 @@ public interface ClassTransformer {
 
     void transform(ClassReader reader, ClassWriter writer);
 
+    /**
+     * The flags to use in the construction of the {@link ClassWriter} provided to {@link #transform(ClassReader, ClassWriter)}.
+     *
+     * @return The flags to use
+     * @see ClassWriter for more information as to which flags are available
+     */
+    default int getWriterFlags() {
+        return 0;
+    }
+
     @ApiStatus.Internal
     final class FactoryProvider {
         @Inject


### PR DESCRIPTION
Adds a default method in `ClassTransformer` that allows configuration of the flags supplied to the `ClassWriter` used in the `transform` method.
