### PR TITLE
Show point ranges for parent criteria in rubric export

### DIFF
--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/export/rubric/GermanCSVExporter.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/export/rubric/GermanCSVExporter.kt
@@ -64,16 +64,14 @@ class GermanCSVExporter @Inject constructor(
         val criterion = gradedCriterion.criterion
         val grade = gradedCriterion.grade
         val comments = grade.comments.joinToString("; ")
-        if (gradedCriterion.childCriteria.isEmpty()) {
-            printRecord(
-                criterion.shortDescription,
-                PointRange.toString(criterion),
-                PointRange.toString(grade),
-                comments,
-                criterion.hiddenNotes,
-            )
-        } else {
-            printRecord(criterion.shortDescription, null, null, comments, criterion.hiddenNotes)
+        printRecord(
+            criterion.shortDescription,
+            PointRange.toString(criterion),
+            PointRange.toString(grade),
+            comments,
+            criterion.hiddenNotes,
+        )
+        if (gradedCriterion.childCriteria.isNotEmpty()) {
             for (childGradedCriterion in gradedCriterion.childCriteria) {
                 printCriterion(childGradedCriterion)
             }

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/export/rubric/MoodleJSONExporter.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/export/rubric/MoodleJSONExporter.kt
@@ -107,20 +107,13 @@ class MoodleJSONExporter @Inject constructor(
         val criterion = gradedCriterion.criterion
         val grade = gradedCriterion.grade
         val comments = grade.comments.joinToString("<br />")
-        if (gradedCriterion.childCriteria.isEmpty()) {
-            append("<tr>")
-            append("<td>${criterion.shortDescription}</td>")
-            append("<td>${PointRange.toString(criterion)}</td>")
-            append("<td>${PointRange.toString(grade)}</td>")
-            append("<td>$comments</td>")
-            append("</tr>")
-        } else {
-            append("<tr>")
-            append("<td><strong>${criterion.shortDescription}</strong></td>")
-            append("<td></td>")
-            append("<td></td>")
-            append("<td>$comments</td>")
-            append("</tr>")
+        append("<tr>")
+        append("<td>${criterion.shortDescription}</td>")
+        append("<td>${PointRange.toString(criterion)}</td>")
+        append("<td>${PointRange.toString(grade)}</td>")
+        append("<td>$comments</td>")
+        append("</tr>")
+        if (gradedCriterion.childCriteria.isNotEmpty()) {
             for (childGradedCriterion in gradedCriterion.childCriteria) {
                 appendCriterion(childGradedCriterion)
             }


### PR DESCRIPTION
Show point ranges for parent criteria, not just children.

Previously:
```
H1
H1_1 Foo1 [0,1] 1
H1_2 Foo2 [-1,3] 2
```

Now:
```
H1 [-1,4] 3
H1_1 Foo1 [0,1] 1
H1_2 Foo2 [-1,3] 2
```
