### PR TITLE
Log stacktraces for child-process log messages

### DIFF
--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/ProcessWorker.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/ProcessWorker.kt
@@ -31,7 +31,11 @@ import org.slf4j.Logger
 import org.sourcegrade.jagr.launcher.env.Environment
 import org.sourcegrade.jagr.launcher.env.Jagr
 import org.sourcegrade.jagr.launcher.env.logger
-import org.sourcegrade.jagr.launcher.io.*
+import org.sourcegrade.jagr.launcher.io.ProgressAwareOutputStream
+import org.sourcegrade.jagr.launcher.io.SerializerFactory
+import org.sourcegrade.jagr.launcher.io.get
+import org.sourcegrade.jagr.launcher.io.getScoped
+import org.sourcegrade.jagr.launcher.io.openScope
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.ObjectInputStream
@@ -104,7 +108,7 @@ class ProcessWorker(
                 val throwable = ois.readObject() as Throwable? // the throwable field is not serialized in event or message
                 ProgressAwareOutputStream.enabled = false
                 jagr.logger.let<Logger, KFunction2<String, Throwable?, Unit>> {
-                    when (event.level.intLevel()/100) {
+                    when (event.level.intLevel() / 100) {
                         2 -> it::error
                         3 -> it::warn
                         4 -> it::info

--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/ProcessWorker.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/ProcessWorker.kt
@@ -26,17 +26,16 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import org.apache.logging.log4j.core.LogEvent
 import org.slf4j.Logger
+import org.sourcegrade.jagr.launcher.env.Environment
 import org.sourcegrade.jagr.launcher.env.Jagr
 import org.sourcegrade.jagr.launcher.env.logger
-import org.sourcegrade.jagr.launcher.io.SerializerFactory
-import org.sourcegrade.jagr.launcher.io.get
-import org.sourcegrade.jagr.launcher.io.getScoped
-import org.sourcegrade.jagr.launcher.io.openScope
+import org.sourcegrade.jagr.launcher.io.*
 import java.io.ByteArrayOutputStream
 import java.io.File
-import java.nio.charset.StandardCharsets
-import kotlin.reflect.KFunction1
+import java.io.ObjectInputStream
+import kotlin.reflect.KFunction2
 
 class ProcessWorker(
     private val jagr: Jagr,
@@ -100,21 +99,12 @@ class ProcessWorker(
                 jagr.logger.error("${request.submission.info} :: Received unexpected EOF while waiting for child process to complete")
                 return null
             } else if (next == MARK_LOG_MESSAGE_BYTE) {
-                val level = childProcessIn.read()
-                val length = childProcessIn.read() shl 24 or
-                    childProcessIn.read() shl 16 or
-                    childProcessIn.read() shl 8 or
-                    childProcessIn.read()
-                if (length < 0) {
-                    jagr.logger.error("${request.submission.info} :: Received IOException while waiting for child process to complete")
-                    return null
-                }
-                val message: String = runCatching { process.inputStream.readNBytes(length) }.getOrElse {
-                    jagr.logger.error("${request.submission.info} :: Received IOException while waiting for child process to complete")
-                    return null
-                }.toString(StandardCharsets.UTF_8)
-                jagr.logger.let<Logger, KFunction1<String, Unit>> {
-                    when (level) {
+                val ois = ObjectInputStream(childProcessIn)
+                val event = ois.readObject() as LogEvent
+                val throwable = ois.readObject() as Throwable? // the throwable field is not serialized in event or message
+                ProgressAwareOutputStream.enabled = false
+                jagr.logger.let<Logger, KFunction2<String, Throwable?, Unit>> {
+                    when (event.level.intLevel()/100) {
                         2 -> it::error
                         3 -> it::warn
                         4 -> it::info
@@ -122,7 +112,9 @@ class ProcessWorker(
                         6 -> it::trace
                         else -> it::info
                     }
-                }(message)
+                }(event.message.formattedMessage, throwable)
+                ProgressAwareOutputStream.enabled = true
+                ProgressAwareOutputStream.progressBar?.print(Environment.stdOut)
             }
         }
         val bytes: ByteArray = runCatching { process.inputStream.readAllBytes() }.getOrElse {

--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/io/MagicAppender.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/io/MagicAppender.kt
@@ -16,7 +16,6 @@ import org.sourcegrade.jagr.launcher.env.Environment.stdOut
 import org.sourcegrade.jagr.launcher.executor.ProcessWorker
 import java.io.ObjectOutputStream
 import java.io.Serializable
-import java.nio.charset.StandardCharsets
 
 @Plugin(
     name = "MagicAppender",

--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/io/MagicAppender.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/io/MagicAppender.kt
@@ -14,6 +14,7 @@ import org.apache.logging.log4j.core.config.plugins.PluginFactory
 import org.apache.logging.log4j.core.layout.PatternLayout
 import org.sourcegrade.jagr.launcher.env.Environment.stdOut
 import org.sourcegrade.jagr.launcher.executor.ProcessWorker
+import java.io.ObjectOutputStream
 import java.io.Serializable
 import java.nio.charset.StandardCharsets
 
@@ -34,14 +35,9 @@ class MagicAppender private constructor(
     override fun append(event: LogEvent) {
         val out = stdOut
         out.write(ProcessWorker.MARK_LOG_MESSAGE_BYTE)
-        out.write(event.level.intLevel() / 100)
-        val msg = event.message.formattedMessage.toByteArray(StandardCharsets.UTF_8)
-        val msgLength = msg.size
-        out.write(msgLength shr 24)
-        out.write(msgLength shr 16)
-        out.write(msgLength shr 8)
-        out.write(msgLength)
-        out.write(msg)
+        val oos = ObjectOutputStream(out)
+        oos.writeObject(event)
+        oos.writeObject(event.thrown)
     }
 
     @Suppress("unused")

--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/io/ProgressAwareOutputStream.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/io/ProgressAwareOutputStream.kt
@@ -16,7 +16,7 @@ class ProgressAwareOutputStream(private val delegate: PrintStream) : OutputStrea
 
     private fun writeWithProgress(progressBar: ProgressBar, b: Int) {
         delegate.write(b)
-        if (b == newLine) {
+        if (enabled && b == newLine) {
             progressBar.print(delegate)
         }
     }
@@ -24,5 +24,6 @@ class ProgressAwareOutputStream(private val delegate: PrintStream) : OutputStrea
     companion object {
         const val newLine = '\n'.code
         var progressBar: ProgressBar? = null
+        var enabled = true
     }
 }


### PR DESCRIPTION
Currently log statements from child-processes do not contain a stacktrace.


Fix this and adjust the progress bar to allow multi-line log statements.