### PR TITLE
Accept old TU-IDs in the default studentID regex

### DIFF
--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/env/Config.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/env/Config.kt
@@ -122,7 +122,7 @@ class Extras {
     @ConfigSerializable
     class MoodleUnpack : Extra() {
         val assignmentIdRegex = ".*Abgabe.*(?<assignmentId>[0-9]+).*[.]zip"
-        val studentIdRegex: String = "[a-z]{2}[0-9]{2}[a-z]{4}"
+        val studentIdRegex: String = "([a-z]{2}[0-9]{2}[a-z]{4})|([a-z]+_[a-z]+)"
     }
 
     val moodleUnpack: MoodleUnpack = MoodleUnpack()


### PR DESCRIPTION
Change the studentIdRegex in the default config to accept old and new TU-IDs.
