### PR TITLE
Provide correct ClassLoader to ASM's ClassWriter

### DIFF
--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/executor/BatchCompilation.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/executor/BatchCompilation.kt
@@ -25,9 +25,11 @@ import org.sourcegrade.jagr.api.testing.Submission
 import org.sourcegrade.jagr.core.compiler.ResourceExtractor
 import org.sourcegrade.jagr.core.compiler.java.JavaCompiledContainer
 import org.sourcegrade.jagr.core.compiler.java.JavaSourceFile
+import org.sourcegrade.jagr.core.compiler.java.RuntimeClassLoader
 import org.sourcegrade.jagr.core.compiler.java.RuntimeJarLoader
 import org.sourcegrade.jagr.core.compiler.java.RuntimeResources
 import org.sourcegrade.jagr.core.compiler.java.loadCompiled
+import org.sourcegrade.jagr.core.compiler.java.plus
 import org.sourcegrade.jagr.core.compiler.submissionInfo
 import org.sourcegrade.jagr.core.parallelMapNotNull
 import org.sourcegrade.jagr.core.testing.GraderInfoImpl
@@ -141,7 +143,8 @@ class CompiledBatchFactoryImpl @Inject constructor(
         }
         val original = runtimeJarLoader.compileSources(replacedSources, libraries)
         val transformed = try {
-            transformerApplier.transform(original)
+            val classLoader = RuntimeClassLoader(original.runtimeResources + libraries)
+            transformerApplier.transform(original, classLoader)
         } catch (e: Throwable) {
             // create a copy of the original compile result but throw out runtime resources (compiled classes and resources)
             original.copy(

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/transformer/TransformerApplier.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/transformer/TransformerApplier.kt
@@ -30,30 +30,30 @@ import kotlin.reflect.KFunction
 import kotlin.reflect.jvm.javaMethod
 
 fun interface TransformationApplier {
-    fun transform(result: JavaCompiledContainer): JavaCompiledContainer
+    fun transform(result: JavaCompiledContainer, classLoader: ClassLoader): JavaCompiledContainer
 }
 
 operator fun TransformationApplier.plus(other: TransformationApplier): TransformationApplier {
     if (this is NoOpTransformerAppliedImpl) return other
     if (other is NoOpTransformerAppliedImpl) return this
-    return TransformationApplier { other.transform(transform(it)) }
+    return TransformationApplier { result, classLoader -> other.transform(transform(result, classLoader), classLoader) }
 }
 
 private object NoOpTransformerAppliedImpl : TransformationApplier {
-    override fun transform(result: JavaCompiledContainer): JavaCompiledContainer = result
+    override fun transform(result: JavaCompiledContainer, classLoader: ClassLoader): JavaCompiledContainer = result
 }
 
 private class TransformerApplierImpl(private val transformer: ClassTransformer) : TransformationApplier {
-    override fun transform(result: JavaCompiledContainer): JavaCompiledContainer = result.copy(
-        runtimeResources = result.runtimeResources.copy(classes = result.runtimeResources.classes.transform(transformer))
+    override fun transform(result: JavaCompiledContainer, classLoader: ClassLoader): JavaCompiledContainer = result.copy(
+        runtimeResources = result.runtimeResources.copy(classes = result.runtimeResources.classes.transform(transformer, classLoader))
     )
 }
 
 private class MultiTransformerApplierImpl(private vararg val transformers: ClassTransformer) : TransformationApplier {
-    override fun transform(result: JavaCompiledContainer): JavaCompiledContainer {
+    override fun transform(result: JavaCompiledContainer, classLoader: ClassLoader): JavaCompiledContainer {
         var classes = result.runtimeResources.classes
         for (transformer in transformers) {
-            classes = classes.transform(transformer)
+            classes = classes.transform(transformer, classLoader)
         }
         return result.copy(runtimeResources = result.runtimeResources.copy(classes = classes))
     }
@@ -69,18 +69,24 @@ fun applierOf(vararg transformers: ClassTransformer): TransformationApplier {
 
 infix fun List<ClassTransformer>.useWhen(predicate: (JavaCompiledContainer) -> Boolean): TransformationApplier {
     val backing = MultiTransformerApplierImpl(*toTypedArray())
-    return TransformationApplier { if (predicate(it)) backing.transform(it) else it }
-}
-
-fun Map<String, CompiledClass>.transform(transformer: ClassTransformer): Map<String, CompiledClass> {
-    return mapValues { (_, compiledClass) ->
-        compiledClass.transformed(transformer.transform(compiledClass.bytecode))
+    return TransformationApplier { result, classLoader ->
+        if (predicate(result)) backing.transform(result, classLoader) else result
     }
 }
 
-fun ClassTransformer.transform(byteArray: ByteArray): ByteArray {
+fun Map<String, CompiledClass>.transform(transformer: ClassTransformer, classLoader: ClassLoader): Map<String, CompiledClass> {
+    return mapValues { (_, compiledClass) ->
+        compiledClass.transformed(transformer.transform(compiledClass.bytecode, classLoader))
+    }
+}
+
+fun ClassTransformer.transform(byteArray: ByteArray, classLoader: ClassLoader): ByteArray {
     val reader = ClassReader(byteArray)
-    val writer = ClassWriter(reader, writerFlags)
+    val writer = object : ClassWriter(reader, writerFlags) {
+        override fun getClassLoader(): ClassLoader {
+            return classLoader
+        }
+    }
     transform(reader, writer)
     return writer.toByteArray()
 }


### PR DESCRIPTION
By default, ASM's `ClassWriter` uses the classloader that it was loaded by. In this case, this is the default app classloader.

For some transformations, it is necessary for ASM to have access to the target class, which it fetches from this classloader. If this happens, and a target class is in a submission or grader, it causes a `ClassNotFoundExcecption` in `ClassWriter#getCommonSuperClass`.

This PR addresses this issue by providing the `ClassWriter` used for transformations with the correct classloader (that has all target classes).


