### PR TITLE
Properly synchronize RubricCollector

### DIFF
--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/MutableRubricCollector.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/MutableRubricCollector.kt
@@ -22,9 +22,9 @@ package org.sourcegrade.jagr.launcher.executor
 import org.sourcegrade.jagr.launcher.env.Jagr
 
 sealed interface MutableRubricCollector : RubricCollector {
-    fun setListener(listener: (GradingResult) -> Unit)
-    fun allocate(queue: GradingQueue)
-    fun start(request: GradingRequest): GradingJob
+    suspend fun setListener(listener: (GradingResult) -> Unit)
+    suspend fun allocate(queue: GradingQueue)
+    suspend fun start(request: GradingRequest): GradingJob
 }
 
 fun emptyCollector(jagr: Jagr = Jagr): MutableRubricCollector = RubricCollectorImpl(jagr)

--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/MutableRubricCollector.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/MutableRubricCollector.kt
@@ -25,6 +25,11 @@ sealed interface MutableRubricCollector : RubricCollector {
     suspend fun setListener(listener: (GradingResult) -> Unit)
     suspend fun allocate(queue: GradingQueue)
     suspend fun start(request: GradingRequest): GradingJob
+    suspend fun <T> startBlock(block: suspend (StartBlock) -> T): T
+
+    interface StartBlock {
+        fun start(request: GradingRequest): GradingJob
+    }
 }
 
 fun emptyCollector(jagr: Jagr = Jagr): MutableRubricCollector = RubricCollectorImpl(jagr)

--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/ProcessWorker.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/ProcessWorker.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import org.apache.logging.log4j.core.LogEvent
 import org.slf4j.Logger
 import org.sourcegrade.jagr.launcher.env.Environment
@@ -118,7 +119,11 @@ class ProcessWorker(
                     }
                 }(event.message.formattedMessage, throwable)
                 ProgressAwareOutputStream.enabled = true
-                ProgressAwareOutputStream.progressBar?.print(Environment.stdOut)
+                ProgressAwareOutputStream.progressBar?.let {
+                    runBlocking {
+                        print(Environment.stdOut)
+                    }
+                }
             }
         }
         val bytes: ByteArray = runCatching { process.inputStream.readAllBytes() }.getOrElse {

--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/ProgressBar.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/ProgressBar.kt
@@ -19,7 +19,6 @@
 
 package org.sourcegrade.jagr.launcher.executor
 
-import kotlinx.coroutines.runBlocking
 import java.io.PrintStream
 import java.text.DecimalFormat
 import java.time.Duration

--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/ProgressBar.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/ProgressBar.kt
@@ -19,6 +19,7 @@
 
 package org.sourcegrade.jagr.launcher.executor
 
+import kotlinx.coroutines.runBlocking
 import java.io.PrintStream
 import java.text.DecimalFormat
 import java.time.Duration
@@ -61,9 +62,9 @@ class ProgressBar(
         }
     }
 
-    fun print(out: PrintStream) {
-        val finished = rubricCollector.gradingFinished.size
-        val total = rubricCollector.total
+    suspend fun print(out: PrintStream) = rubricCollector.withSnapshot { snapshot ->
+        val finished = snapshot.gradingFinished.size
+        val total = snapshot.total
         val progressDecimal = finished.toDouble() / total.toDouble().coerceAtLeast(0.0)
         val formattedPercentage = decimalFormat.format(progressDecimal * 100.0)
         val barCount = (ProgressBarProvider.INNER_WIDTH * progressDecimal).toInt()
@@ -81,8 +82,8 @@ class ProgressBar(
         sb.append(formattedPercentage)
         sb.append('%')
         sb.append(" ($finished/$total)")
-        if (rubricCollector.gradingScheduled.size in 1 until showElementsIfLessThan) {
-            sb.append(" Remaining: [${rubricCollector.gradingScheduled.joinToString { it.request.submission.toString() }}]")
+        if (snapshot.gradingScheduled.size in 1 until showElementsIfLessThan) {
+            sb.append(" Remaining: [${snapshot.gradingScheduled.joinToString { it.request.submission.toString() }}]")
         }
         // if more submissions are finished, save the time and how many submissions were graded since last save
         if (finished != lastFinished) {

--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/RubricCollector.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/RubricCollector.kt
@@ -20,9 +20,19 @@
 package org.sourcegrade.jagr.launcher.executor
 
 sealed interface RubricCollector {
-    val gradingScheduled: List<GradingJob>
-    val gradingRunning: List<GradingJob>
-    val gradingFinished: List<GradingResult>
-    val total: Int
-    val remaining: Int
+    suspend fun <T> withGradingScheduled(block: suspend (List<GradingJob>) -> T): T
+    suspend fun <T> withGradingRunning(block: suspend (List<GradingJob>) -> T): T
+    suspend fun <T> withGradingFinished(block: suspend (List<GradingResult>) -> T): T
+    suspend fun getTotal(): Int
+    suspend fun getRemaining(): Int
+    suspend fun toSnapshot(): Snapshot
+    suspend fun <T> withSnapshot(block: suspend (Snapshot) -> T): T
+
+    data class Snapshot(
+        val gradingScheduled: List<GradingJob>,
+        val gradingRunning: List<GradingJob>,
+        val gradingFinished: List<GradingResult>,
+        val total: Int,
+        val remaining: Int,
+    )
 }

--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/RubricCollectorImpl.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/RubricCollectorImpl.kt
@@ -22,37 +22,80 @@ package org.sourcegrade.jagr.launcher.executor
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.sourcegrade.jagr.launcher.env.Jagr
 import org.sourcegrade.jagr.launcher.env.logger
 
 internal class RubricCollectorImpl(private val jagr: Jagr) : MutableRubricCollector {
     private val queued = mutableListOf<GradingQueue>()
-    override val gradingScheduled = mutableListOf<GradingJob>()
-    override val gradingRunning = mutableListOf<GradingJob>()
-    override val gradingFinished = mutableListOf<GradingResult>()
-    override val total: Int
+    private val gradingScheduled = mutableListOf<GradingJob>()
+    private val gradingRunning = mutableListOf<GradingJob>()
+    private val gradingFinished = mutableListOf<GradingResult>()
+
+    private val total: Int
         get() = queued.sumOf { it.total }
-    override val remaining: Int
+    private val remaining: Int
         get() = queued.sumOf { it.remaining }
 
     private var listener: (GradingResult) -> Unit = {}
     private val scope = CoroutineScope(Dispatchers.Unconfined)
 
-    override fun allocate(queue: GradingQueue) {
+    private val mutex = Mutex()
+
+    override suspend fun <T> withGradingScheduled(block: suspend (List<GradingJob>) -> T): T = mutex.withLock {
+        block(gradingScheduled)
+    }
+
+    override suspend fun <T> withGradingRunning(block: suspend (List<GradingJob>) -> T): T = mutex.withLock {
+        block(gradingRunning)
+    }
+
+    override suspend fun <T> withGradingFinished(block: suspend (List<GradingResult>) -> T): T = mutex.withLock {
+        block(gradingFinished)
+    }
+
+
+    override suspend fun getTotal(): Int = mutex.withLock { total }
+    override suspend fun getRemaining(): Int = mutex.withLock { remaining }
+
+    override suspend fun toSnapshot(): RubricCollector.Snapshot = mutex.withLock {
+        RubricCollector.Snapshot(
+            gradingScheduled.toList(),
+            gradingRunning.toList(),
+            gradingFinished.toList(),
+            total,
+            remaining,
+        )
+    }
+
+    override suspend fun <T> withSnapshot(block: suspend (RubricCollector.Snapshot) -> T): T = mutex.withLock {
+        return block(RubricCollector.Snapshot(
+            gradingScheduled,
+            gradingRunning,
+            gradingFinished,
+            total,
+            remaining,
+        ))
+    }
+
+    override suspend fun allocate(queue: GradingQueue) = mutex.withLock {
         queued += queue
     }
 
-    override fun setListener(listener: (GradingResult) -> Unit) {
+    override suspend fun setListener(listener: (GradingResult) -> Unit) = mutex.withLock {
         this.listener = listener
     }
 
-    override fun start(request: GradingRequest): GradingJob {
+    override suspend fun start(request: GradingRequest): GradingJob = mutex.withLock {
         val job = GradingJob(request)
         gradingRunning += job
         scope.launch {
             try {
                 val result = job.result.await()
-                gradingFinished.add(result)
+                mutex.withLock {
+                    gradingFinished.add(result)
+                }
                 listener(result)
             } catch (e: Exception) {
                 jagr.logger.error("An error occurred receiving result for grading job", e)

--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/RubricCollectorImpl.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/RubricCollectorImpl.kt
@@ -55,7 +55,6 @@ internal class RubricCollectorImpl(private val jagr: Jagr) : MutableRubricCollec
         block(gradingFinished)
     }
 
-
     override suspend fun getTotal(): Int = mutex.withLock { total }
     override suspend fun getRemaining(): Int = mutex.withLock { remaining }
 
@@ -70,13 +69,15 @@ internal class RubricCollectorImpl(private val jagr: Jagr) : MutableRubricCollec
     }
 
     override suspend fun <T> withSnapshot(block: suspend (RubricCollector.Snapshot) -> T): T = mutex.withLock {
-        return block(RubricCollector.Snapshot(
-            gradingScheduled,
-            gradingRunning,
-            gradingFinished,
-            total,
-            remaining,
-        ))
+        return block(
+            RubricCollector.Snapshot(
+                gradingScheduled,
+                gradingRunning,
+                gradingFinished,
+                total,
+                remaining,
+            )
+        )
     }
 
     override suspend fun allocate(queue: GradingQueue) = mutex.withLock {

--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/io/ProgressAwareOutputStream.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/io/ProgressAwareOutputStream.kt
@@ -1,5 +1,6 @@
 package org.sourcegrade.jagr.launcher.io
 
+import kotlinx.coroutines.runBlocking
 import org.sourcegrade.jagr.launcher.executor.ProgressBar
 import java.io.OutputStream
 import java.io.PrintStream
@@ -17,7 +18,9 @@ class ProgressAwareOutputStream(private val delegate: PrintStream) : OutputStrea
     private fun writeWithProgress(progressBar: ProgressBar, b: Int) {
         delegate.write(b)
         if (enabled && b == newLine) {
-            progressBar.print(delegate)
+            runBlocking {
+                progressBar.print(delegate)
+            }
         }
     }
 

--- a/src/main/kotlin/org/sourcegrade/jagr/Logging.kt
+++ b/src/main/kotlin/org/sourcegrade/jagr/Logging.kt
@@ -22,13 +22,13 @@ package org.sourcegrade.jagr
 import org.sourcegrade.jagr.api.rubric.GradedRubric
 import org.sourcegrade.jagr.launcher.env.Jagr
 import org.sourcegrade.jagr.launcher.env.logger
-import org.sourcegrade.jagr.launcher.executor.RubricCollector
+import org.sourcegrade.jagr.launcher.executor.GradingResult
 
-fun RubricCollector.logHistogram(jagr: Jagr) {
+fun List<GradingResult>.logHistogram(jagr: Jagr) {
     val histogram = mutableMapOf<Int, Int>()
     var minPoints = 0
     var maxPoints = 0
-    val allRubrics = gradingFinished.flatMap { it.rubrics.keys }
+    val allRubrics = flatMap { it.rubrics.keys }
     for (rubric in allRubrics) {
         val prev = histogram.computeIfAbsent(rubric.grade.minPoints) { 0 }
         histogram[rubric.grade.minPoints] = prev + 1

--- a/src/main/kotlin/org/sourcegrade/jagr/StandardGrading.kt
+++ b/src/main/kotlin/org/sourcegrade/jagr/StandardGrading.kt
@@ -97,8 +97,10 @@ class StandardGrading(
         executor.start(collector)
         ProgressAwareOutputStream.progressBar = null
         Environment.cleanupMainProcess()
-        collector.logHistogram(jagr)
-        val rubricCount = collector.gradingFinished.sumOf { it.rubrics.size }
+        val rubricCount = collector.withGradingFinished { gradingFinished ->
+            gradingFinished.logHistogram(jagr)
+            gradingFinished.sumOf { it.rubrics.size }
+        }
         if (rubricCount == 0) {
             jagr.logger.warn("No rubrics!")
         } else {


### PR DESCRIPTION
Addresses the lack of synchronization currently causing race conditions in `RubricCollector` and `MutableRubricCollector` in certain situations.

Prevents direct (unsynchronized) access to the underlying lists in `RubricCollector`, instead opting for suspended/synchronized methods (locked by a `kotlinx.coroutines.sync.Mutex`).

Breaks API in `RubricCollector` and `MutableRubricCollector` as direct access to some internals has been removed.
