### PR TITLE
Add custom ClassTransformer order

### DIFF
--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/executor/BatchCompilation.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/executor/BatchCompilation.kt
@@ -21,6 +21,7 @@ package org.sourcegrade.jagr.core.executor
 
 import com.google.inject.Inject
 import org.slf4j.Logger
+import org.sourcegrade.jagr.api.testing.ClassTransformerOrder
 import org.sourcegrade.jagr.api.testing.Submission
 import org.sourcegrade.jagr.core.compiler.ResourceExtractor
 import org.sourcegrade.jagr.core.compiler.java.JavaCompiledContainer
@@ -40,8 +41,8 @@ import org.sourcegrade.jagr.core.transformer.CommonClassTransformer
 import org.sourcegrade.jagr.core.transformer.SubmissionVerificationTransformer
 import org.sourcegrade.jagr.core.transformer.TransformationApplier
 import org.sourcegrade.jagr.core.transformer.applierOf
+import org.sourcegrade.jagr.core.transformer.createApplier
 import org.sourcegrade.jagr.core.transformer.plus
-import org.sourcegrade.jagr.core.transformer.useWhen
 import org.sourcegrade.jagr.launcher.io.GraderJar
 import org.sourcegrade.jagr.launcher.io.GradingBatch
 import org.sourcegrade.jagr.launcher.io.ResourceContainer
@@ -103,12 +104,19 @@ class CompiledBatchFactoryImpl @Inject constructor(
      * submissions only if the grader contains a rubric for it
      */
     private fun createTransformerApplierFromGraders(graders: List<GraderJar>): TransformationApplier {
-        val base = applierOf(SubmissionVerificationTransformer(), commonClassTransformer)
-        return graders.map { graderJar ->
-            graderJar.configuration.transformers useWhen { result ->
-                result.submissionInfo?.assignmentId?.let(graderJar.info.assignmentIds::contains) == true
+        fun GraderJar.createApplier(order: ClassTransformerOrder): TransformationApplier =
+            configuration.transformers.createApplier(order) { result ->
+                result.submissionInfo?.assignmentId?.let(info.assignmentIds::contains) == true
             }
-        }.fold(base) { a, b -> a + b }
+
+        fun createApplier(order: ClassTransformerOrder): TransformationApplier =
+            graders.map { it.createApplier(order) }.fold(applierOf()) { a, b -> a + b }
+
+        return sequenceOf(
+            createApplier(ClassTransformerOrder.PRE),
+            applierOf(SubmissionVerificationTransformer(), commonClassTransformer),
+            createApplier(ClassTransformerOrder.DEFAULT),
+        ).reduce { a, b -> a + b }
     }
 
     private fun calculateSubmissionFileOverrides(graders: List<GraderJar>): Map<String, List<String>> {

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/RubricConfigurationImpl.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/RubricConfigurationImpl.kt
@@ -20,17 +20,20 @@
 package org.sourcegrade.jagr.core.testing
 
 import org.sourcegrade.jagr.api.testing.ClassTransformer
+import org.sourcegrade.jagr.api.testing.ClassTransformerOrder
 import org.sourcegrade.jagr.api.testing.RubricConfiguration
 import java.util.Collections
 
 class RubricConfigurationImpl : RubricConfiguration {
-    private val transformers = mutableListOf<ClassTransformer>()
+    private val transformers = mutableMapOf<ClassTransformerOrder, MutableList<ClassTransformer>>()
     private val fileNameSolutionOverrides = mutableListOf<String>()
-    override fun getTransformers(): List<ClassTransformer> = Collections.unmodifiableList(transformers)
-    override fun getFileNameSolutionOverrides(): MutableList<String> = Collections.unmodifiableList(fileNameSolutionOverrides)
+    override fun getTransformers(): Map<ClassTransformerOrder, List<ClassTransformer>> =
+        Collections.unmodifiableMap(transformers) // TODO: Make nested list unmodifiable
 
-    override fun addTransformer(transformer: ClassTransformer): RubricConfiguration {
-        transformers += transformer
+    override fun getFileNameSolutionOverrides(): List<String> = Collections.unmodifiableList(fileNameSolutionOverrides)
+
+    override fun addTransformer(transformer: ClassTransformer, order: ClassTransformerOrder): RubricConfiguration {
+        transformers.computeIfAbsent(order) { mutableListOf() } += transformer
         return this
     }
 

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/RubricConfigurationImpl.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/RubricConfigurationImpl.kt
@@ -28,7 +28,7 @@ class RubricConfigurationImpl : RubricConfiguration {
     private val transformers = mutableMapOf<ClassTransformerOrder, MutableList<ClassTransformer>>()
     private val fileNameSolutionOverrides = mutableListOf<String>()
     override fun getTransformers(): Map<ClassTransformerOrder, List<ClassTransformer>> =
-        Collections.unmodifiableMap(transformers) // TODO: Make nested list unmodifiable
+        transformers.asSequence().map { (a, b) -> a to Collections.unmodifiableList(b) }.toMap()
 
     override fun getFileNameSolutionOverrides(): List<String> = Collections.unmodifiableList(fileNameSolutionOverrides)
 

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/transformer/TransformerApplier.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/transformer/TransformerApplier.kt
@@ -74,7 +74,7 @@ fun Map<ClassTransformerOrder, List<ClassTransformer>>.createApplier(
     order: ClassTransformerOrder,
     predicate: (JavaCompiledContainer) -> Boolean,
 ): TransformationApplier {
-    val backing = MultiTransformerApplierImpl(*requireNotNull(this[order]).toTypedArray())
+    val backing = MultiTransformerApplierImpl(*(this[order] ?: return applierOf()).toTypedArray())
     return TransformationApplier { result, classLoader ->
         if (predicate(result)) backing.transform(result, classLoader) else result
     }

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/transformer/TransformerApplier.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/transformer/TransformerApplier.kt
@@ -24,6 +24,7 @@ import org.objectweb.asm.ClassWriter
 import org.objectweb.asm.MethodVisitor
 import org.objectweb.asm.Type
 import org.sourcegrade.jagr.api.testing.ClassTransformer
+import org.sourcegrade.jagr.api.testing.ClassTransformerOrder
 import org.sourcegrade.jagr.core.compiler.java.CompiledClass
 import org.sourcegrade.jagr.core.compiler.java.JavaCompiledContainer
 import kotlin.reflect.KFunction
@@ -69,8 +70,11 @@ fun applierOf(vararg transformers: ClassTransformer): TransformationApplier {
     }
 }
 
-infix fun List<ClassTransformer>.useWhen(predicate: (JavaCompiledContainer) -> Boolean): TransformationApplier {
-    val backing = MultiTransformerApplierImpl(*toTypedArray())
+fun Map<ClassTransformerOrder, List<ClassTransformer>>.createApplier(
+    order: ClassTransformerOrder,
+    predicate: (JavaCompiledContainer) -> Boolean,
+): TransformationApplier {
+    val backing = MultiTransformerApplierImpl(*requireNotNull(this[order]).toTypedArray())
     return TransformationApplier { result, classLoader ->
         if (predicate(result)) backing.transform(result, classLoader) else result
     }

--- a/grader-api/src/main/java/org/sourcegrade/jagr/api/testing/ClassTransformerOrder.java
+++ b/grader-api/src/main/java/org/sourcegrade/jagr/api/testing/ClassTransformerOrder.java
@@ -1,0 +1,31 @@
+/*
+ *   Jagr - SourceGrade.org
+ *   Copyright (C) 2021 Alexander Staeding
+ *   Copyright (C) 2021 Contributors
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.sourcegrade.jagr.api.testing;
+
+public enum ClassTransformerOrder {
+
+
+    /**
+     * Before submission verification.
+     */
+    PRE,
+
+    DEFAULT,
+}

--- a/grader-api/src/main/java/org/sourcegrade/jagr/api/testing/ClassTransformerOrder.java
+++ b/grader-api/src/main/java/org/sourcegrade/jagr/api/testing/ClassTransformerOrder.java
@@ -21,11 +21,13 @@ package org.sourcegrade.jagr.api.testing;
 
 public enum ClassTransformerOrder {
 
-
     /**
      * Before submission verification.
      */
     PRE,
 
+    /**
+     * After submission verification.
+     */
     DEFAULT,
 }

--- a/grader-api/src/main/java/org/sourcegrade/jagr/api/testing/RubricConfiguration.java
+++ b/grader-api/src/main/java/org/sourcegrade/jagr/api/testing/RubricConfiguration.java
@@ -23,15 +23,20 @@ import org.jetbrains.annotations.ApiStatus;
 import org.objectweb.asm.Type;
 
 import java.util.List;
+import java.util.Map;
 
 @ApiStatus.NonExtendable
 public interface RubricConfiguration {
 
-    List<ClassTransformer> getTransformers();
+    Map<ClassTransformerOrder, List<ClassTransformer>> getTransformers();
 
     List<String> getFileNameSolutionOverrides();
 
-    RubricConfiguration addTransformer(ClassTransformer transformer);
+    RubricConfiguration addTransformer(ClassTransformer transformer, ClassTransformerOrder order);
+
+    default RubricConfiguration addTransformer(ClassTransformer transformer) {
+        return addTransformer(transformer, ClassTransformerOrder.DEFAULT);
+    }
 
     /**
      * Adds a file that will be overridden in the submission from the solution.


### PR DESCRIPTION
Sometimes, it is useful to provide transformations that are run before submission verification. For example, it is possible that submissions have a legitimate use for `System.exit`, which should not disqualify the submission from being graded.

While submissions with illegal instructions (such as `System.exit`) should be eliminated by the end of the compilation/transformation phase, it should be possible to transform these illegal instructions to prevent submissions that would otherwise be thrown out, to be graded.

This PR adds a new enum `ClassTransformerOrder` and a new overload to `RubricConfiguration`, namely `addTransformer(ClassTransformer, ClassTransformerOrder). Currently, the two values for the order are `DEFAULT` and `PRE` (more may be added later).

Transformers registered under `PRE` will be run *before* submission verification, and all transformers registered under `DEFAULT` will run after all of Jagr's own transformers.

The scope of this PR is mostly a minor change (addition) with only a usually unused method being incompatibly changed.

Breaking API change: `RubricConfiguration.getTransformers` returns `Map<ClassTransformerOrder, List<ClassTransformer>>` instead of `List<ClassTransformer>`.