### PR TITLE
Make studentId parsing more robust

### DIFF
--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/extra/MoodleUnpack.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/extra/MoodleUnpack.kt
@@ -34,7 +34,7 @@ class MoodleUnpack @Inject constructor(
     override val name: String = "moodle-unpack"
     override fun run() {
         val submissions = File(config.dir.submissions)
-        val studentIdRegex = Regex(config.extras.moodleUnpack.studentIdRegex)
+        val studentRegex = Regex(config.extras.moodleUnpack.studentRegex)
         val unpackedFiles: MutableList<SubmissionInfoVerification> = mutableListOf()
         for (candidate in submissions.listFiles { _, t -> t.endsWith(".zip") }!!) {
             logger.info("extra($name) :: Discovered candidate zip $candidate")
@@ -46,9 +46,9 @@ class MoodleUnpack @Inject constructor(
                 ?.let { "h$it" }
                 ?: "none"
             for (entry in zipFile.entries()) {
-                if (!entry.name.endsWith(".jar")) continue
+                val matcher = studentRegex.matchEntire(entry.name) ?: continue
                 try {
-                    unpackedFiles += zipFile.unpackEntry(entry.name.split("/"), entry, submissions, studentIdRegex, assignmentId)
+                    unpackedFiles += zipFile.unpackEntry(entry, submissions, assignmentId, matcher)
                 } catch (e: Throwable) {
                     logger.info("extra($name) :: Unable to unpack entry ${entry.name} in candidate $candidate", e)
                 }
@@ -58,14 +58,13 @@ class MoodleUnpack @Inject constructor(
     }
 
     private fun ZipFile.unpackEntry(
-        path: List<String>,
         entry: ZipEntry,
         directory: File,
-        studentIdRegex: Regex,
         assignmentId: String,
+        matcher: MatchResult,
     ): SubmissionInfoVerification {
-        val studentId = path[1].split(" - ").run { this[size - 1] }.takeIf { studentIdRegex.matches(it) }
-        val fileName = "$studentId-${path[path.size - 1]}"
+        val studentId = matcher.groups["studentId"]?.value
+        val fileName = "$assignmentId-$studentId.jar"
         if (studentId == null) {
             logger.warn("extra(moodle-unpack) :: Unpacking unknown studentId in file $fileName")
         } else {

--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/env/Config.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/env/Config.kt
@@ -122,7 +122,7 @@ class Extras {
     @ConfigSerializable
     class MoodleUnpack : Extra() {
         val assignmentIdRegex = ".*Abgabe.*(?<assignmentId>[0-9]{2}).*[.]zip"
-        val studentIdRegex: String = "([a-z]{2}[0-9]{2}[a-z]{4})|([a-z]+_[a-z]+)"
+        val studentRegex: String = ".* - (?<studentId>([a-z]{2}[0-9]{2}[a-z]{4})|([a-z]+_[a-z]+))/submissions/.*[.]jar"
     }
 
     val moodleUnpack: MoodleUnpack = MoodleUnpack()


### PR DESCRIPTION
Improve studentId parsing from moodle zip by using a named regex group.

Breaking change: Replaces config option `studentIdRegex` with `studentRegex`.