### PR TITLE
Do not enable timeouts until JUnit tests start execution

### DIFF
--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/executor/TimeoutHandler.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/executor/TimeoutHandler.kt
@@ -46,7 +46,7 @@ object TimeoutHandler {
     private val timeoutIndividual by lazy { config.executor.timeoutIndividual }
     private val timeoutTotal by lazy { config.executor.timeoutTotal }
 
-    private val lastTimeout = ThreadLocal.withInitial { AtomicLong() }
+    private val lastTimeout = ThreadLocal.withInitial { AtomicLong(-1) }
     private val testClassNames = ThreadLocal.withInitial<List<String>> { emptyList() }
     private val mxBean = ManagementFactory.getThreadMXBean()
 

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/JavaRuntimeTester.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/JavaRuntimeTester.kt
@@ -81,6 +81,7 @@ class JavaRuntimeTester @Inject constructor(
             val summaryListener = SummaryGeneratingListener()
             val statusListener = TestStatusListenerImpl(logger)
             TimeoutHandler.setClassNames(map { it.className })
+            TimeoutHandler.resetTimeout()
             launcher.execute(testPlan, summaryListener, statusListener)
             // if total timeout has been reached, reset so that the rubric provider doesn't throw an error
             TimeoutHandler.disableTimeout()


### PR DESCRIPTION
Fixes #79 