### PR TITLE
Add style plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,5 @@
 import com.github.jengelman.gradle.plugins.shadow.transformers.Log4j2PluginsCacheFileTransformer
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import org.jlleitschuh.gradle.ktlint.KtlintExtension
 import org.sourcegrade.jagr.script.JagrPublishPlugin
 
 @Suppress("DSL_SCOPE_VIOLATION") // https://youtrack.jetbrains.com/issue/KTIJ-19369
@@ -10,7 +9,7 @@ plugins {
     alias(libs.plugins.kotlin.kapt) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.shadow)
-    id("org.jlleitschuh.gradle.ktlint") version "10.2.1"
+    alias(libs.plugins.style)
 }
 
 dependencies {
@@ -58,7 +57,7 @@ val projectVersion = file("version").readLines().first()
 project.extra["apiVersion"] = projectVersion.replace(".[0-9]+(?=($|-SNAPSHOT))".toRegex(), "")
 
 allprojects {
-    apply(plugin = "org.jlleitschuh.gradle.ktlint")
+    apply(plugin = "org.sourcegrade.style")
 
     group = "org.sourcegrade"
     version = projectVersion
@@ -66,10 +65,6 @@ allprojects {
     project.findProperty("buildNumber")
         ?.takeIf { version.toString().contains("SNAPSHOT") }
         ?.also { version = version.toString().replace("SNAPSHOT", "RC$it") }
-
-    configure<KtlintExtension> {
-        enableExperimentalRules.set(true)
-    }
 
     tasks {
         withType<KotlinCompile> {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,3 +34,4 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 shadow = { id = "com.github.johnrengelman.shadow", version = "7.1.2" }
+style = { id = "org.sourcegrade.style", version = "2.1.0" }


### PR DESCRIPTION
Finish fixing and enforcing codestyle that was started with #59.

Now that https://github.com/checkstyle/checkstyle/issues/11736 is merged, the checkstyle task is able ignore types annotaed with `@ApiStatus.Internal`, which was not possible earlier and blocked the addition of the style plugin.

Fixes #91 