### PR TITLE
Search correct parent classloader in findClass(String)

### DIFF
--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/compiler/java/RuntimeClassLoader.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/compiler/java/RuntimeClassLoader.kt
@@ -38,11 +38,7 @@ class RuntimeClassLoader(
     override fun findClass(name: String): Class<*> {
         val compiledClass = runtimeResources.classes[name] ?: return super.findClass(name)
         val byteCode: ByteArray = compiledClass.bytecode
-        try {
-            return defineClass(name, byteCode, 0, byteCode.size)
-        } catch (e: Exception) {
-            throw IllegalStateException("Failed to define class $name", e)
-        }
+        return defineClass(name, byteCode, 0, byteCode.size)
     }
 
     override fun findResource(name: String): URL? {

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/compiler/java/RuntimeClassLoader.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/compiler/java/RuntimeClassLoader.kt
@@ -36,17 +36,7 @@ class RuntimeClassLoader(
 
     @Throws(ClassNotFoundException::class, ClassFormatError::class)
     override fun findClass(name: String): Class<*> {
-        val compiledClass = runtimeResources.classes[name]
-            ?: try {
-                return super.findClass(name)
-            } catch (e: Exception) {
-                null
-            }
-            ?: try {
-                return Class.forName(name)
-            } catch (e: Exception) {
-                throw ClassNotFoundException("Failed to load class $name from $parent", e)
-            }
+        val compiledClass = runtimeResources.classes[name] ?: return super.findClass(name)
         val byteCode: ByteArray = compiledClass.bytecode
         try {
             return defineClass(name, byteCode, 0, byteCode.size)


### PR DESCRIPTION
Currently, the `RuntimeClassLoader` uses the system class loader as a parent by default. This causes an issue when used in a larger program where the system classloader is not the one with access to Jagr's or its dependencies' classes.

These programs use a separate classloader to load external modules (e.g. jagr) which causes an issue in the `findClass(String)` method in `RuntimeClassLoader` because the incorrect parent classloader is used. In this case, the classloader that loaded Jagr itself must be used as a parent.