### PR TITLE
Force single assignmentId in grader jar

### DIFF
--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/executor/BatchCompilation.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/executor/BatchCompilation.kt
@@ -76,7 +76,7 @@ class CompiledBatchFactoryImpl @Inject constructor(
 
         // maps assignment ids to files that should be replaced with solution files
         val replacements = submissionFileOverrides.mapValues { (assignmentId, solutionOverrides) ->
-            val gradersForAssignment = graders.filter { it.info.assignmentId.contains(assignmentId) }
+            val gradersForAssignment = graders.filter { it.info.assignmentId == assignmentId }
             solutionOverrides.mapNotNull { solutionOverride ->
                 gradersForAssignment.firstNotNullOfOrNull { it.container.source.sourceFiles[solutionOverride] }
             }.associateBy { it.fileName }

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/GraderInfoImpl.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/GraderInfoImpl.kt
@@ -27,13 +27,16 @@ import org.sourcegrade.jagr.launcher.io.SerializationScope
 import org.sourcegrade.jagr.launcher.io.SerializerFactory
 import org.sourcegrade.jagr.launcher.io.read
 import org.sourcegrade.jagr.launcher.io.readList
+import org.sourcegrade.jagr.launcher.io.readMap
 import org.sourcegrade.jagr.launcher.io.write
 import org.sourcegrade.jagr.launcher.io.writeList
+import org.sourcegrade.jagr.launcher.io.writeMap
 
 @Serializable
 data class GraderInfoImpl(
     override val name: String,
     override val assignmentId: String,
+    override val sourceDescriptors: Map<String, List<String>>,
     override val sourceSets: List<SourceSetInfoImpl>,
 ) : GraderInfo {
 
@@ -41,12 +44,14 @@ data class GraderInfoImpl(
         override fun read(scope: SerializationScope.Input) = GraderInfoImpl(
             scope.input.readUTF(),
             scope.read(),
+            scope.readMap(),
             scope.readList(),
         )
 
         override fun write(obj: GraderInfoImpl, scope: SerializationScope.Output) {
             scope.output.writeUTF(obj.name)
             scope.write(obj.assignmentId)
+            scope.writeMap(obj.sourceDescriptors)
             scope.writeList(obj.sourceSets)
         }
     }

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/GraderInfoImpl.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/GraderInfoImpl.kt
@@ -27,16 +27,13 @@ import org.sourcegrade.jagr.launcher.io.SerializationScope
 import org.sourcegrade.jagr.launcher.io.SerializerFactory
 import org.sourcegrade.jagr.launcher.io.read
 import org.sourcegrade.jagr.launcher.io.readList
-import org.sourcegrade.jagr.launcher.io.readMap
 import org.sourcegrade.jagr.launcher.io.write
 import org.sourcegrade.jagr.launcher.io.writeList
-import org.sourcegrade.jagr.launcher.io.writeMap
 
 @Serializable
 data class GraderInfoImpl(
     override val name: String,
     override val assignmentId: String,
-    override val sourceDescriptors: Map<String, List<String>>,
     override val sourceSets: List<SourceSetInfoImpl>,
 ) : GraderInfo {
 
@@ -44,14 +41,12 @@ data class GraderInfoImpl(
         override fun read(scope: SerializationScope.Input) = GraderInfoImpl(
             scope.input.readUTF(),
             scope.read(),
-            scope.readMap(),
             scope.readList(),
         )
 
         override fun write(obj: GraderInfoImpl, scope: SerializationScope.Output) {
             scope.output.writeUTF(obj.name)
             scope.write(obj.assignmentId)
-            scope.writeMap(obj.sourceDescriptors)
             scope.writeList(obj.sourceSets)
         }
     }

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/GraderInfoImpl.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/GraderInfoImpl.kt
@@ -25,26 +25,28 @@ import org.sourcegrade.jagr.core.compiler.ResourceExtractor
 import org.sourcegrade.jagr.launcher.io.GraderInfo
 import org.sourcegrade.jagr.launcher.io.SerializationScope
 import org.sourcegrade.jagr.launcher.io.SerializerFactory
+import org.sourcegrade.jagr.launcher.io.read
 import org.sourcegrade.jagr.launcher.io.readList
+import org.sourcegrade.jagr.launcher.io.write
 import org.sourcegrade.jagr.launcher.io.writeList
 
 @Serializable
 data class GraderInfoImpl(
     override val name: String,
-    override val assignmentIds: List<String>,
+    override val assignmentId: String,
     override val sourceSets: List<SourceSetInfoImpl>,
 ) : GraderInfo {
 
     companion object Factory : SerializerFactory<GraderInfoImpl> {
         override fun read(scope: SerializationScope.Input) = GraderInfoImpl(
             scope.input.readUTF(),
-            scope.readList(),
+            scope.read(),
             scope.readList(),
         )
 
         override fun write(obj: GraderInfoImpl, scope: SerializationScope.Output) {
             scope.output.writeUTF(obj.name)
-            scope.writeList(obj.assignmentIds)
+            scope.write(obj.assignmentId)
             scope.writeList(obj.sourceSets)
         }
     }

--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/io/GraderInfo.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/io/GraderInfo.kt
@@ -26,7 +26,7 @@ import kotlin.properties.ReadOnlyProperty
  */
 interface GraderInfo {
     val name: String
-    val assignmentIds: List<String>
+    val assignmentId: String
     val sourceSets: List<SourceSetInfo>
 }
 

--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/io/GraderInfo.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/io/GraderInfo.kt
@@ -27,12 +27,15 @@ import kotlin.properties.ReadOnlyProperty
 interface GraderInfo {
     val name: String
     val assignmentId: String
+    val sourceDescriptors: Map<String, List<String>>
     val sourceSets: List<SourceSetInfo>
 }
 
-val GraderInfo.graderFiles: List<String> by named("grader")
+val GraderInfo.graderFiles: List<String> by withDescriptor("grader")
 
-val GraderInfo.solutionFiles: List<String> by named("solution")
+val GraderInfo.solutionFiles: List<String> by withDescriptor("solution")
 
-private fun named(name: String): ReadOnlyProperty<GraderInfo, List<String>> =
-    ReadOnlyProperty { info, _ -> info.sourceSets.first { it.name == name }.files }
+private fun withDescriptor(name: String): ReadOnlyProperty<GraderInfo, List<String>> = ReadOnlyProperty { info, _ ->
+    val descriptors = checkNotNull(info.sourceDescriptors[name]) { "No source descriptor named $name" }
+    info.sourceSets.filter { it.name in descriptors }.flatMap { it.files }
+}

--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/io/GraderInfo.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/io/GraderInfo.kt
@@ -27,15 +27,12 @@ import kotlin.properties.ReadOnlyProperty
 interface GraderInfo {
     val name: String
     val assignmentId: String
-    val sourceDescriptors: Map<String, List<String>>
     val sourceSets: List<SourceSetInfo>
 }
 
-val GraderInfo.graderFiles: List<String> by withDescriptor("grader")
+val GraderInfo.graderFiles: List<String> by named("grader")
 
-val GraderInfo.solutionFiles: List<String> by withDescriptor("solution")
+val GraderInfo.solutionFiles: List<String> by named("solution")
 
-private fun withDescriptor(name: String): ReadOnlyProperty<GraderInfo, List<String>> = ReadOnlyProperty { info, _ ->
-    val descriptors = checkNotNull(info.sourceDescriptors[name]) { "No source descriptor named $name" }
-    info.sourceSets.filter { it.name in descriptors }.flatMap { it.files }
-}
+private fun named(name: String): ReadOnlyProperty<GraderInfo, List<String>> =
+    ReadOnlyProperty { info, _ -> info.sourceSets.first { it.name == name }.files }


### PR DESCRIPTION
Simplifies the grader jar structure by forcing them to target a single assignment id