### PR TITLE
Add option to specify custom export build script

### DIFF
--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/export/submission/GradleSubmissionExporter.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/export/submission/GradleSubmissionExporter.kt
@@ -58,6 +58,17 @@ class GradleSubmissionExporter @Inject constructor(
             name = graderJar?.info?.name ?: DEFAULT_EXPORT_NAME
         }
         writeSkeleton()
+        if (graderJar != null && graderJar.configuration.exportBuildScriptPath != null) {
+            addResource {
+                name = "build.gradle.kts"
+                val buildScriptResourceName = graderJar.configuration.exportBuildScriptPath!!
+                graderJar.container.source.resources[buildScriptResourceName].also {
+                    it?.inputStream()?.copyTo(outputStream)
+                } ?: logger.error("Could not read custom build script: $buildScriptResourceName")
+            }
+        } else {
+            writeGradleResource(resource = "build.gradle.kts_", targetName = "build.gradle.kts")
+        }
         val filteredSubmissions = if (graderJar == null) {
             submissions
         } else {
@@ -110,7 +121,6 @@ class GradleSubmissionExporter @Inject constructor(
         addResource(wrapperBuilder.build())
         writeGradleResource(classLoader, resource = "gradlew")
         writeGradleResource(classLoader, resource = "gradlew.bat")
-        writeGradleResource(classLoader, resource = "build.gradle.kts_", targetName = "build.gradle.kts")
         writeGradleResource(classLoader, resource = "gradle-wrapper.properties", targetDir = "gradle/wrapper/")
     }
 

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/RubricConfigurationImpl.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/RubricConfigurationImpl.kt
@@ -27,10 +27,13 @@ import java.util.Collections
 class RubricConfigurationImpl : RubricConfiguration {
     private val transformers = mutableMapOf<ClassTransformerOrder, MutableList<ClassTransformer>>()
     private val fileNameSolutionOverrides = mutableListOf<String>()
+    private var exportBuildScriptPath: String? = null
     override fun getTransformers(): Map<ClassTransformerOrder, List<ClassTransformer>> =
         transformers.asSequence().map { (a, b) -> a to Collections.unmodifiableList(b) }.toMap()
 
     override fun getFileNameSolutionOverrides(): List<String> = Collections.unmodifiableList(fileNameSolutionOverrides)
+
+    override fun getExportBuildScriptPath() = exportBuildScriptPath
 
     override fun addTransformer(transformer: ClassTransformer, order: ClassTransformerOrder): RubricConfiguration {
         transformers.computeIfAbsent(order) { mutableListOf() } += transformer
@@ -39,6 +42,11 @@ class RubricConfigurationImpl : RubricConfiguration {
 
     override fun addFileNameSolutionOverride(fileName: String): RubricConfiguration {
         fileNameSolutionOverrides += fileName
+        return this
+    }
+
+    override fun setExportBuildScriptPath(path: String?): RubricConfiguration {
+        exportBuildScriptPath = path
         return this
     }
 }

--- a/grader-api/src/main/java/org/sourcegrade/jagr/api/testing/RubricConfiguration.java
+++ b/grader-api/src/main/java/org/sourcegrade/jagr/api/testing/RubricConfiguration.java
@@ -20,6 +20,7 @@
 package org.sourcegrade.jagr.api.testing;
 
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
 import org.objectweb.asm.Type;
 import org.sourcegrade.jagr.api.rubric.RubricProvider;
 
@@ -107,5 +108,5 @@ public interface RubricConfiguration {
      *
      * @param path The path to the build script, relative to the grader resource directory
      */
-    RubricConfiguration setExportBuildScriptPath(String path);
+    RubricConfiguration setExportBuildScriptPath(@Nullable String path);
 }

--- a/grader-api/src/main/java/org/sourcegrade/jagr/api/testing/RubricConfiguration.java
+++ b/grader-api/src/main/java/org/sourcegrade/jagr/api/testing/RubricConfiguration.java
@@ -53,6 +53,13 @@ public interface RubricConfiguration {
     List<String> getFileNameSolutionOverrides();
 
     /**
+     * The path to the custom export build script relative to the grader resource directory.
+     *
+     * @return the path to the custom export build script relative to the grader resource directory
+     */
+    String getExportBuildScriptPath();
+
+    /**
      * Adds a transformer to the list of transformers to apply to every matching submission.
      *
      * @param transformer The {@link ClassTransformer} to add
@@ -93,4 +100,12 @@ public interface RubricConfiguration {
     default RubricConfiguration addFileNameSolutionOverride(Class<?> clazz) {
         return addFileNameSolutionOverride(Type.getInternalName(clazz) + ".java");
     }
+
+    /**
+     * Sets the path to the custom export build script, relative to the grader resource directory.
+     * If set to {@code null} or left unset, the default build script will be used.
+     *
+     * @param path The path to the build script, relative to the grader resource directory
+     */
+    RubricConfiguration setExportBuildScriptPath(String path);
 }

--- a/grader-api/src/main/java/org/sourcegrade/jagr/api/testing/RubricConfiguration.java
+++ b/grader-api/src/main/java/org/sourcegrade/jagr/api/testing/RubricConfiguration.java
@@ -58,7 +58,7 @@ public interface RubricConfiguration {
      *
      * @return the path to the custom export build script relative to the grader resource directory
      */
-    String getExportBuildScriptPath();
+    @Nullable String getExportBuildScriptPath();
 
     /**
      * Adds a transformer to the list of transformers to apply to every matching submission.


### PR DESCRIPTION
Add option to specify a custom build script that will be used as `build.gradle.kts` during exports. This closes #22.