### PR TITLE
Add jagrVersion field to GraderInfo

### DIFF
--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/io/GraderInfo.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/io/GraderInfo.kt
@@ -31,18 +31,21 @@ import kotlin.properties.ReadOnlyProperty
 data class GraderInfo(
     val assignmentId: String,
     val name: String,
+    val jagrVersion: String,
     val sourceSets: List<SourceSetInfo>,
 ) {
     companion object Factory : SerializerFactory<GraderInfo> {
         override fun read(scope: SerializationScope.Input) = GraderInfo(
-            scope.read(),
+            scope.input.readUTF(),
+            scope.input.readUTF(),
             scope.input.readUTF(),
             scope.readList(),
         )
 
         override fun write(obj: GraderInfo, scope: SerializationScope.Output) {
+            scope.output.writeUTF(obj.assignmentId)
             scope.output.writeUTF(obj.name)
-            scope.write(obj.assignmentId)
+            scope.output.writeUTF(obj.jagrVersion)
             scope.writeList(obj.sourceSets)
         }
     }

--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/io/GraderInfo.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/io/GraderInfo.kt
@@ -30,8 +30,8 @@ import kotlin.properties.ReadOnlyProperty
 @Serializable
 data class GraderInfo(
     val assignmentId: String,
-    val name: String,
     val jagrVersion: String,
+    val name: String,
     val sourceSets: List<SourceSetInfo>,
 ) {
     companion object Factory : SerializerFactory<GraderInfo> {
@@ -44,8 +44,8 @@ data class GraderInfo(
 
         override fun write(obj: GraderInfo, scope: SerializationScope.Output) {
             scope.output.writeUTF(obj.assignmentId)
-            scope.output.writeUTF(obj.name)
             scope.output.writeUTF(obj.jagrVersion)
+            scope.output.writeUTF(obj.name)
             scope.writeList(obj.sourceSets)
         }
     }


### PR DESCRIPTION
This may be used as an informative extra field (written automatically by a Gradle plugin) that could also help migrate different versions of the grader info JSON in the future.
