### PR TITLE
Add RuntimeClassLoader to grader-api

### DIFF
--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/executor/BatchCompilation.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/executor/BatchCompilation.kt
@@ -27,7 +27,7 @@ import org.sourcegrade.jagr.core.compiler.InfoJsonResourceExtractor
 import org.sourcegrade.jagr.core.compiler.ResourceExtractor
 import org.sourcegrade.jagr.core.compiler.java.JavaCompiledContainer
 import org.sourcegrade.jagr.core.compiler.java.JavaSourceFile
-import org.sourcegrade.jagr.core.compiler.java.RuntimeClassLoader
+import org.sourcegrade.jagr.core.compiler.java.RuntimeClassLoaderImpl
 import org.sourcegrade.jagr.core.compiler.java.RuntimeJarLoader
 import org.sourcegrade.jagr.core.compiler.java.RuntimeResources
 import org.sourcegrade.jagr.core.compiler.java.loadCompiled
@@ -148,7 +148,7 @@ class CompiledBatchFactoryImpl @Inject constructor(
         }
         val original = runtimeJarLoader.compileSources(replacedSources, libraries)
         val transformed = try {
-            val classLoader = RuntimeClassLoader(original.runtimeResources + libraries)
+            val classLoader = RuntimeClassLoaderImpl(original.runtimeResources + libraries)
             transformerApplier.transform(original, classLoader)
         } catch (e: Throwable) {
             // create a copy of the original compile result but throw out runtime resources (compiled classes and resources)

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/FallbackRuntimeTester.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/FallbackRuntimeTester.kt
@@ -21,7 +21,7 @@ package org.sourcegrade.jagr.core.testing
 
 import org.sourcegrade.jagr.api.testing.Submission
 import org.sourcegrade.jagr.api.testing.TestCycle
-import org.sourcegrade.jagr.core.compiler.java.RuntimeClassLoader
+import org.sourcegrade.jagr.core.compiler.java.RuntimeClassLoaderImpl
 import org.sourcegrade.jagr.core.compiler.java.plus
 
 class FallbackRuntimeTester : RuntimeTester {
@@ -30,7 +30,7 @@ class FallbackRuntimeTester : RuntimeTester {
         val rubricProviders = grader.rubricProviders[info.assignmentId] ?: return null
         var resources = grader.container.runtimeResources
         resources += submission.compileResult.runtimeResources + submission.libraries
-        val classLoader = RuntimeClassLoader(resources)
+        val classLoader = RuntimeClassLoaderImpl(resources)
         val notes = listOf(
             "The grading process was forcibly terminated.",
             "Please check if you have an infinite loop or infinite recursion.",

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/FallbackTestCycle.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/FallbackTestCycle.kt
@@ -21,16 +21,16 @@ package org.sourcegrade.jagr.core.testing
 
 import org.sourcegrade.jagr.api.testing.Submission
 import org.sourcegrade.jagr.api.testing.TestCycle
-import org.sourcegrade.jagr.core.compiler.java.RuntimeClassLoader
+import org.sourcegrade.jagr.core.compiler.java.RuntimeClassLoaderImpl
 
 class FallbackTestCycle(
     private val rubricProviderClassNames: List<String>,
     private val submission: Submission,
-    private val classLoader: RuntimeClassLoader,
+    private val classLoader: RuntimeClassLoaderImpl,
     private val notes: List<String>,
 ) : TestCycle {
     override fun getRubricProviderClassNames(): List<String> = rubricProviderClassNames
-    override fun getClassLoader(): ClassLoader = classLoader
+    override fun getClassLoader(): RuntimeClassLoaderImpl = classLoader
     override fun getSubmission(): Submission = submission
     override fun getTestsSucceededCount(): Int = -1
     override fun getTestsStartedCount(): Int = -1

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/GraderJarImpl.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/GraderJarImpl.kt
@@ -25,7 +25,7 @@ import org.sourcegrade.jagr.api.rubric.RubricProvider
 import org.sourcegrade.jagr.api.rubric.TestForSubmission
 import org.sourcegrade.jagr.core.compiler.graderInfo
 import org.sourcegrade.jagr.core.compiler.java.JavaCompiledContainer
-import org.sourcegrade.jagr.core.compiler.java.RuntimeClassLoader
+import org.sourcegrade.jagr.core.compiler.java.RuntimeClassLoaderImpl
 import org.sourcegrade.jagr.core.compiler.java.RuntimeResources
 import org.sourcegrade.jagr.core.compiler.java.plus
 import org.sourcegrade.jagr.launcher.io.GraderJar
@@ -81,7 +81,7 @@ class GraderJarImpl(
         }
         val rubricProviders: MutableMap<String, MutableList<String>> = mutableMapOf()
         val testProviders: MutableMap<String, MutableList<String>> = mutableMapOf()
-        val baseClassLoader = RuntimeClassLoader(container.runtimeResources + libraries)
+        val baseClassLoader = RuntimeClassLoaderImpl(container.runtimeResources + libraries)
         for (className in container.runtimeResources.classes.keys) {
             val clazz = baseClassLoader.loadClass(className)
             rubricProviders.putIfRubric(clazz)

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/JavaRuntimeTester.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/JavaRuntimeTester.kt
@@ -29,7 +29,7 @@ import org.junit.platform.launcher.core.LauncherFactory
 import org.junit.platform.launcher.listeners.SummaryGeneratingListener
 import org.sourcegrade.jagr.api.testing.Submission
 import org.sourcegrade.jagr.api.testing.TestCycle
-import org.sourcegrade.jagr.core.compiler.java.RuntimeClassLoader
+import org.sourcegrade.jagr.core.compiler.java.RuntimeClassLoaderImpl
 import org.sourcegrade.jagr.core.compiler.java.plus
 import org.sourcegrade.jagr.core.executor.TimeoutHandler
 
@@ -48,7 +48,7 @@ class JavaRuntimeTester @Inject constructor(
             )
             return null
         }
-        val classLoader = RuntimeClassLoader(
+        val classLoader = RuntimeClassLoaderImpl(
             submission.compileResult.runtimeResources +
                 submission.libraries +
                 grader.containerWithoutSolution.runtimeResources

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/JavaSubmission.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/JavaSubmission.kt
@@ -40,6 +40,8 @@ data class JavaSubmission(
     override fun getInfo(): String = submissionInfo.toString()
     override fun getCompileResult(): JavaCompiledContainer = compileResult
     override fun getSourceFile(fileName: String): SourceFile? = compileResult.source.sourceFiles[fileName]
+
+    @Deprecated("Deprecated in Java")
     override fun getClassNames(): Set<String> = Collections.unmodifiableSet(compileResult.runtimeResources.classes.keys)
 
     override fun toString(): String = "$submissionInfo(${compileResult.info.name})"

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/JavaTestCycle.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/JavaTestCycle.kt
@@ -21,7 +21,7 @@ package org.sourcegrade.jagr.core.testing
 
 import org.sourcegrade.jagr.api.testing.Submission
 import org.sourcegrade.jagr.api.testing.TestCycle
-import org.sourcegrade.jagr.core.compiler.java.RuntimeClassLoader
+import org.sourcegrade.jagr.core.compiler.java.RuntimeClassLoaderImpl
 import org.sourcegrade.jagr.core.compiler.java.RuntimeResources
 import org.sourcegrade.jagr.launcher.io.SerializationScope
 import org.sourcegrade.jagr.launcher.io.SerializerFactory
@@ -35,13 +35,13 @@ import org.sourcegrade.jagr.launcher.io.writeList
 data class JavaTestCycle(
     private val rubricProviderClassNames: List<String>,
     private val submission: JavaSubmission,
-    private val classLoader: RuntimeClassLoader,
+    private val classLoader: RuntimeClassLoaderImpl,
     private var testsSucceededCount: Int = -1,
     private var testsStartedCount: Int = -1,
 ) : TestCycle {
     private var jUnitResult: TestCycle.JUnitResult? = null
     override fun getRubricProviderClassNames(): List<String> = rubricProviderClassNames
-    override fun getClassLoader(): ClassLoader = classLoader
+    override fun getClassLoader(): RuntimeClassLoaderImpl = classLoader
     override fun getSubmission(): JavaSubmission = submission
     override fun getTestsSucceededCount(): Int = testsSucceededCount
     override fun getTestsStartedCount(): Int = testsStartedCount

--- a/grader-api/src/main/java/org/sourcegrade/jagr/api/testing/RuntimeClassLoader.java
+++ b/grader-api/src/main/java/org/sourcegrade/jagr/api/testing/RuntimeClassLoader.java
@@ -1,0 +1,76 @@
+/*
+ *   Jagr - SourceGrade.org
+ *   Copyright (C) 2021-2022 Alexander Staeding
+ *   Copyright (C) 2021-2022 Contributors
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.sourcegrade.jagr.api.testing;
+
+import java.util.Set;
+
+/**
+ * A {@link ClassLoader} used to load classes for each {@link Submission}.
+ */
+public interface RuntimeClassLoader {
+
+    /**
+     * Loads the class with the specified name.
+     *
+     * @param name The name of the class
+     * @return The loaded class
+     */
+    Class<?> loadClass(String name);
+
+    /**
+     * Loads and transforms the class with the specified name with the provided transformers.
+     *
+     * <p>
+     * The resulting class is defined from the bytecode resulting from the chain of transformations.
+     * </p>
+     *
+     * @param name         The name of the class to load
+     * @param transformers The transformers to apply to the class
+     * @return The transformed class
+     */
+    Class<?> loadClass(String name, ClassTransformer... transformers);
+
+    /**
+     * Loads and transforms the class with the specified name with the provided transformers.
+     *
+     * <p>
+     * The resulting class is defined from the bytecode resulting from the chain of transformations.
+     * </p>
+     *
+     * @param name         The name of the class to load
+     * @param transformers The transformers to apply to the class
+     * @return The transformed class
+     */
+    Class<?> loadClass(String name, Iterable<? extends ClassTransformer> transformers);
+
+    /**
+     * The names of all classes in this submission.
+     *
+     * @return The names of all classes in this submission
+     */
+    Set<String> getClassNames();
+
+    /**
+     * The names of all resources (no classes) in this submission.
+     *
+     * @return The names of all resources (no classes) in this submission
+     */
+    Set<String> getResourceNames();
+}

--- a/grader-api/src/main/java/org/sourcegrade/jagr/api/testing/Submission.java
+++ b/grader-api/src/main/java/org/sourcegrade/jagr/api/testing/Submission.java
@@ -55,8 +55,13 @@ public interface Submission {
     /**
      * <b>Experimental API. May be moved in a future release.</b>
      *
+     * <p>
+     * Deprecated in favor of {@link TestCycle#getClassLoader()} and {@link RuntimeClassLoader#getClassNames()}.
+     * </p>
+     *
      * @return An immutable set of Java class names from this submission.
+     * @deprecated Use {@link RuntimeClassLoader#getClassNames()} instead.
      */
-    @ApiStatus.Experimental
+    @Deprecated(forRemoval = true)
     Set<String> getClassNames();
 }

--- a/grader-api/src/main/java/org/sourcegrade/jagr/api/testing/TestCycle.java
+++ b/grader-api/src/main/java/org/sourcegrade/jagr/api/testing/TestCycle.java
@@ -52,7 +52,7 @@ public interface TestCycle {
      *
      * @return The {@link ClassLoader} used in this test cycle
      */
-    ClassLoader getClassLoader();
+    RuntimeClassLoader getClassLoader();
 
     /**
      * The {@link Submission} used in this test cycle.
@@ -94,6 +94,7 @@ public interface TestCycle {
      */
     @ApiStatus.NonExtendable
     interface JUnitResult {
+
         /**
          * The {@link TestPlan} used to execute the tests.
          *


### PR DESCRIPTION
Adds some new functionality via the `RuntimeClassLoader` exposed in the API.

1. It is now possible to load a class with transformers that create a new class object with those transformations
2. `getClassNames()` / `getResourceNames()` now available in the `RuntimeClassLoader`. This replaces the method `getClassNames()` in `Submission` which is now deprecated.
