### PR TITLE
Add rubricClassName to grader info

### DIFF
--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/export/submission/GradleSubmissionExporter.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/export/submission/GradleSubmissionExporter.kt
@@ -77,7 +77,7 @@ class GradleSubmissionExporter @Inject constructor(
         val filteredSubmissions = if (graderJar == null) {
             submissions
         } else {
-            submissions.filter { graderJar.info.rubricProviderName == (it as JavaSubmission).submissionInfo.assignmentId }
+            submissions.filter { graderJar.info.assignmentId == (it as JavaSubmission).submissionInfo.assignmentId }
         }
         for (submission in filteredSubmissions) {
             writeSubmission(submission, graderJar)

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/export/submission/GradleSubmissionExporter.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/export/submission/GradleSubmissionExporter.kt
@@ -77,7 +77,7 @@ class GradleSubmissionExporter @Inject constructor(
         val filteredSubmissions = if (graderJar == null) {
             submissions
         } else {
-            submissions.filter { graderJar.info.rubricClassName == (it as JavaSubmission).submissionInfo.assignmentId }
+            submissions.filter { graderJar.info.rubricProviderName == (it as JavaSubmission).submissionInfo.assignmentId }
         }
         for (submission in filteredSubmissions) {
             writeSubmission(submission, graderJar)

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/export/submission/GradleSubmissionExporter.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/export/submission/GradleSubmissionExporter.kt
@@ -77,7 +77,7 @@ class GradleSubmissionExporter @Inject constructor(
         val filteredSubmissions = if (graderJar == null) {
             submissions
         } else {
-            submissions.filter { graderJar.rubricProviders.containsKey((it as JavaSubmission).submissionInfo.assignmentId) }
+            submissions.filter { graderJar.info.rubricClassName == (it as JavaSubmission).submissionInfo.assignmentId }
         }
         for (submission in filteredSubmissions) {
             writeSubmission(submission, graderJar)

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/FallbackRuntimeTester.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/FallbackRuntimeTester.kt
@@ -34,6 +34,6 @@ class FallbackRuntimeTester : RuntimeTester {
             "The grading process was forcibly terminated.",
             "Please check if you have an infinite loop or infinite recursion.",
         )
-        return FallbackTestCycle(grader.info.rubricClassName, submission, classLoader, notes)
+        return FallbackTestCycle(grader.info.rubricProviderName, submission, classLoader, notes)
     }
 }

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/FallbackRuntimeTester.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/FallbackRuntimeTester.kt
@@ -26,8 +26,7 @@ import org.sourcegrade.jagr.core.compiler.java.plus
 
 class FallbackRuntimeTester : RuntimeTester {
     override fun createTestCycle(grader: GraderJarImpl, submission: Submission): TestCycle? {
-        val info = (submission as JavaSubmission).submissionInfo
-        val rubricProviders = grader.rubricProviders[info.assignmentId] ?: return null
+        submission as JavaSubmission
         var resources = grader.container.runtimeResources
         resources += submission.compileResult.runtimeResources + submission.libraries
         val classLoader = RuntimeClassLoaderImpl(resources)
@@ -35,6 +34,6 @@ class FallbackRuntimeTester : RuntimeTester {
             "The grading process was forcibly terminated.",
             "Please check if you have an infinite loop or infinite recursion.",
         )
-        return FallbackTestCycle(rubricProviders, submission, classLoader, notes)
+        return FallbackTestCycle(grader.info.rubricClassName, submission, classLoader, notes)
     }
 }

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/FallbackTestCycle.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/FallbackTestCycle.kt
@@ -29,7 +29,7 @@ class FallbackTestCycle(
     private val classLoader: RuntimeClassLoaderImpl,
     private val notes: List<String>,
 ) : TestCycle {
-    override fun getRubricProviderClassName(): String = rubricProviderClassName
+    override fun getRubricProviderName(): String = rubricProviderClassName
     override fun getClassLoader(): RuntimeClassLoaderImpl = classLoader
     override fun getSubmission(): Submission = submission
     override fun getTestsSucceededCount(): Int = -1

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/FallbackTestCycle.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/FallbackTestCycle.kt
@@ -24,12 +24,12 @@ import org.sourcegrade.jagr.api.testing.TestCycle
 import org.sourcegrade.jagr.core.compiler.java.RuntimeClassLoaderImpl
 
 class FallbackTestCycle(
-    private val rubricProviderClassNames: List<String>,
+    private val rubricProviderClassName: String,
     private val submission: Submission,
     private val classLoader: RuntimeClassLoaderImpl,
     private val notes: List<String>,
 ) : TestCycle {
-    override fun getRubricProviderClassNames(): List<String> = rubricProviderClassNames
+    override fun getRubricProviderClassName(): String = rubricProviderClassName
     override fun getClassLoader(): RuntimeClassLoaderImpl = classLoader
     override fun getSubmission(): Submission = submission
     override fun getTestsSucceededCount(): Int = -1

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/GraderJarImpl.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/GraderJarImpl.kt
@@ -36,7 +36,7 @@ import org.sourcegrade.jagr.launcher.io.read
 import org.sourcegrade.jagr.launcher.io.solutionFiles
 import org.sourcegrade.jagr.launcher.io.write
 
-class GraderJarImpl constructor(
+class GraderJarImpl(
     private val logger: Logger,
     val container: JavaCompiledContainer,
     libraries: RuntimeResources,

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/GraderJarImpl.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/GraderJarImpl.kt
@@ -76,18 +76,18 @@ class GraderJarImpl(
         var foundRubricProvider = false
         for (className in container.runtimeResources.classes.keys) {
             val clazz = baseClassLoader.loadClass(className)
-            if (clazz.name == info.rubricClassName) {
+            if (clazz.name == info.rubricProviderName) {
                 checkRubricProvider(clazz)
                 foundRubricProvider = true
             }
             testClasses.addIfTest(clazz)
         }
         if (!foundRubricProvider) {
-            error("Grader ${info.name} is missing rubric provider class ${info.rubricClassName}")
+            error("Grader ${info.name} is missing rubric provider class ${info.rubricProviderName}")
         }
         logger.info(
             "Grader ${info.name} discovered " +
-                "rubric provider ${info.rubricClassName} and " +
+                "rubric provider ${info.rubricProviderName} and " +
                 "${testClasses.size} test class${if (testClasses.size == 1) "" else "es"}"
         )
         this.testClassNames = testClasses

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/GraderJarImpl.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/GraderJarImpl.kt
@@ -20,7 +20,6 @@
 package org.sourcegrade.jagr.core.testing
 
 import org.apache.logging.log4j.Logger
-import org.sourcegrade.jagr.api.rubric.RubricForSubmission
 import org.sourcegrade.jagr.api.rubric.RubricProvider
 import org.sourcegrade.jagr.api.rubric.TestForSubmission
 import org.sourcegrade.jagr.core.compiler.graderInfo
@@ -37,7 +36,7 @@ import org.sourcegrade.jagr.launcher.io.read
 import org.sourcegrade.jagr.launcher.io.solutionFiles
 import org.sourcegrade.jagr.launcher.io.write
 
-class GraderJarImpl(
+class GraderJarImpl constructor(
     private val logger: Logger,
     val container: JavaCompiledContainer,
     libraries: RuntimeResources,
@@ -47,16 +46,9 @@ class GraderJarImpl(
     override val configuration = RubricConfigurationImpl()
 
     /**
-     * A map of assignments ids to classes of rubric providers (in the base classloader).
-     *
-     * Classes in this map are guaranteed to have an accessible no-args constructor.
-     */
-    override val rubricProviders: Map<String, List<String>>
-
-    /**
      * A map of assignment ids to JUnit test classes
      */
-    override val testProviders: Map<String, List<String>>
+    override val testClassNames: List<String>
 
     private val graderFiles = info.graderFiles.toSet()
     private val solutionFiles = info.solutionFiles.toSet()
@@ -79,49 +71,55 @@ class GraderJarImpl(
                 error("Grader ${info.name} file $fileName is not declared in the grader-info.json")
             }
         }
-        val rubricProviders: MutableMap<String, MutableList<String>> = mutableMapOf()
-        val testProviders: MutableMap<String, MutableList<String>> = mutableMapOf()
+        val testClasses = mutableListOf<String>()
         val baseClassLoader = RuntimeClassLoaderImpl(container.runtimeResources + libraries)
+        var foundRubricProvider = false
         for (className in container.runtimeResources.classes.keys) {
             val clazz = baseClassLoader.loadClass(className)
-            rubricProviders.putIfRubric(clazz)
-            testProviders.putIfTest(clazz)
+            if (clazz.name == info.rubricClassName) {
+                checkRubricProvider(clazz)
+                foundRubricProvider = true
+            }
+            testClasses.addIfTest(clazz)
+        }
+        if (!foundRubricProvider) {
+            error("Grader ${info.name} is missing rubric provider class ${info.rubricClassName}")
         }
         logger.info(
             "Grader ${info.name} discovered " +
-                "${rubricProviders.size} rubric provider${if (rubricProviders.size == 1) "" else "s"} and " +
-                "${testProviders.size} test provider${if (testProviders.size == 1) "" else "s"}"
+                "rubric provider ${info.rubricClassName} and " +
+                "${testClasses.size} test class${if (testClasses.size == 1) "" else "es"}"
         )
-        this.rubricProviders = rubricProviders
-        this.testProviders = testProviders
+        this.testClassNames = testClasses
     }
 
-    private fun MutableMap<String, MutableList<String>>.putIfRubric(clazz: Class<*>) {
-        val annotation = clazz.getAnnotation(RubricForSubmission::class.java) ?: return
+    private fun checkRubricProvider(clazz: Class<*>) {
         val asRubricProvider = try {
             clazz.asSubclass(RubricProvider::class.java)
         } catch (e: ClassCastException) {
-            logger.error(
-                "Grader ${info.name} class ${clazz.name} annotated with @RubricForSubmission " +
-                    "does not implement RubricProvider! Ignoring..."
-            )
-            return
+            throw IllegalStateException("Grader ${info.name} class declared as rubric provider does not implement RubricProvider", e)
         }
 
         val rubricProvider = try {
             checkNotNull(asRubricProvider.getConstructor().newInstance())
         } catch (e: NoSuchMethodException) {
-            logger.error("Grader ${info.name} rubric provider ${clazz.name} must have an accessible no-args constructor!")
-            return
+            throw IllegalStateException("Grader ${info.name} rubric provider ${clazz.name} must have an accessible no-args constructor!", e)
         }
         rubricProvider.configure(configuration)
-        logger.debug("Grader ${info.name} discovered rubric provider ${clazz.name} for assignment ${annotation.value}")
-        computeIfAbsent(annotation.value) { mutableListOf() }.add(asRubricProvider.name)
     }
 
-    private fun MutableMap<String, MutableList<String>>.putIfTest(clazz: Class<*>) {
+    @Suppress("DEPRECATION")
+    private fun MutableList<String>.addIfTest(clazz: Class<*>) {
         val annotation = clazz.getAnnotation(TestForSubmission::class.java) ?: return
-        computeIfAbsent(annotation.value) { mutableListOf() }.add(clazz.name)
+        add(clazz.name)
+        if (annotation.value.isNotBlank() && annotation.value != clazz.name) {
+            logger.warn(
+                "Grader ${info.name} test class ${clazz.name} " +
+                    "has a non-blank value ${annotation.value} in @TestForSubmission and it does not match " +
+                    "the grader's assignmentId ${info.assignmentId}"
+            )
+            logger.warn("Providing a value to @TestForSubmission is deprecated and will be removed in a future version")
+        }
         logger.debug("Grader ${info.name} discovered test provider ${clazz.name} for assignment ${annotation.value}")
     }
 

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/JavaRuntimeTester.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/JavaRuntimeTester.kt
@@ -49,7 +49,7 @@ class JavaRuntimeTester @Inject constructor(
                 submission.libraries +
                 grader.containerWithoutSolution.runtimeResources
         )
-        val testCycle = JavaTestCycle(grader.info.rubricClassName, submission, classLoader)
+        val testCycle = JavaTestCycle(grader.info.rubricProviderName, submission, classLoader)
         grader.testClassNames
             .map { DiscoverySelectors.selectClass(classLoader.loadClass(it)) }
             .runJUnit(testCycle)

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/JavaRuntimeTester.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/JavaRuntimeTester.kt
@@ -41,7 +41,10 @@ class JavaRuntimeTester @Inject constructor(
         if (submission !is JavaSubmission) return null
         val info = submission.submissionInfo
         if (info.assignmentId != grader.info.assignmentId) {
-            logger.warn("Submission $info is for assignment ${info.assignmentId} but grader is for assignment ${grader.info.assignmentId}")
+            logger.warn(
+                "Submission $info assignmentId '${info.assignmentId}' != " +
+                    "grader's ${grader.info.name} assignmentId '${grader.info.assignmentId}'"
+            )
             return null
         }
         val classLoader = RuntimeClassLoaderImpl(

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/JavaTestCycle.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/JavaTestCycle.kt
@@ -31,14 +31,14 @@ import org.sourcegrade.jagr.launcher.io.openScope
 import org.sourcegrade.jagr.launcher.io.read
 
 data class JavaTestCycle(
-    private val rubricProviderClassName: String,
+    private val rubricProviderName: String,
     private val submission: JavaSubmission,
     private val classLoader: RuntimeClassLoaderImpl,
     private var testsSucceededCount: Int = -1,
     private var testsStartedCount: Int = -1,
 ) : TestCycle {
     private var jUnitResult: TestCycle.JUnitResult? = null
-    override fun getRubricProviderClassName(): String = rubricProviderClassName
+    override fun getRubricProviderName(): String = rubricProviderName
     override fun getClassLoader(): RuntimeClassLoaderImpl = classLoader
     override fun getSubmission(): JavaSubmission = submission
     override fun getTestsSucceededCount(): Int = testsSucceededCount
@@ -65,7 +65,7 @@ data class JavaTestCycle(
         )
 
         override fun write(obj: JavaTestCycle, scope: SerializationScope.Output) {
-            scope.output.writeUTF(obj.rubricProviderClassName)
+            scope.output.writeUTF(obj.rubricProviderName)
             scope.output.writeInt(obj.testsSucceededCount)
             scope.output.writeInt(obj.testsStartedCount)
         }

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/JavaTestCycle.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/JavaTestCycle.kt
@@ -29,18 +29,16 @@ import org.sourcegrade.jagr.launcher.io.get
 import org.sourcegrade.jagr.launcher.io.keyOf
 import org.sourcegrade.jagr.launcher.io.openScope
 import org.sourcegrade.jagr.launcher.io.read
-import org.sourcegrade.jagr.launcher.io.readList
-import org.sourcegrade.jagr.launcher.io.writeList
 
 data class JavaTestCycle(
-    private val rubricProviderClassNames: List<String>,
+    private val rubricProviderClassName: String,
     private val submission: JavaSubmission,
     private val classLoader: RuntimeClassLoaderImpl,
     private var testsSucceededCount: Int = -1,
     private var testsStartedCount: Int = -1,
 ) : TestCycle {
     private var jUnitResult: TestCycle.JUnitResult? = null
-    override fun getRubricProviderClassNames(): List<String> = rubricProviderClassNames
+    override fun getRubricProviderClassName(): String = rubricProviderClassName
     override fun getClassLoader(): RuntimeClassLoaderImpl = classLoader
     override fun getSubmission(): JavaSubmission = submission
     override fun getTestsSucceededCount(): Int = testsSucceededCount
@@ -56,7 +54,7 @@ data class JavaTestCycle(
 
     companion object Factory : SerializerFactory<JavaTestCycle> {
         override fun read(scope: SerializationScope.Input) = JavaTestCycle(
-            scope.readList(),
+            scope.input.readUTF(),
             scope[Submission::class] as JavaSubmission,
             scope.openScope {
                 proxy(keyOf(RuntimeResources::class), RuntimeResources.base)
@@ -67,7 +65,7 @@ data class JavaTestCycle(
         )
 
         override fun write(obj: JavaTestCycle, scope: SerializationScope.Output) {
-            scope.writeList(obj.rubricProviderClassNames)
+            scope.output.writeUTF(obj.rubricProviderClassName)
             scope.output.writeInt(obj.testsSucceededCount)
             scope.output.writeInt(obj.testsStartedCount)
         }

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/RuntimeGraderImpl.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/RuntimeGraderImpl.kt
@@ -53,9 +53,9 @@ class RuntimeGraderImpl @Inject constructor(
     private fun TestCycle.collectResults(): Pair<GradedRubric, String>? {
         val rubricProvider = try {
             // rubric provider must first be loaded again together with submission classes
-            classLoader.loadClass(rubricProviderClassName).getConstructor().newInstance() as RubricProvider
+            classLoader.loadClass(rubricProviderName).getConstructor().newInstance() as RubricProvider
         } catch (e: Throwable) {
-            logger.error("Failed to initialize rubricProvider $rubricProviderClassName for $submission", e)
+            logger.error("Failed to initialize rubric provider $rubricProviderName for $submission", e)
             return null
         }
         val exportFileName = rubricProvider.getOutputFileName(submission) ?: submission.info.toString()

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/RuntimeGraderImpl.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/RuntimeGraderImpl.kt
@@ -50,19 +50,15 @@ class RuntimeGraderImpl @Inject constructor(
             .fold(emptyMap()) { a, b -> a + b }
     }
 
-    private fun TestCycle.collectResults(): Map<GradedRubric, String> {
-        val result: MutableMap<GradedRubric, String> = mutableMapOf()
-        for (rubricProviderName in rubricProviderClassNames) {
-            val rubricProvider = try {
-                // rubric provider must first be loaded again together with submission classes
-                classLoader.loadClass(rubricProviderName).getConstructor().newInstance() as RubricProvider
-            } catch (e: Throwable) {
-                logger.error("Failed to initialize rubricProvider $rubricProviderName for $submission", e)
-                continue
-            }
-            val exportFileName = rubricProvider.getOutputFileName(submission) ?: submission.info.toString()
-            result[rubricProvider.rubric.grade(this)] = exportFileName
+    private fun TestCycle.collectResults(): Pair<GradedRubric, String>? {
+        val rubricProvider = try {
+            // rubric provider must first be loaded again together with submission classes
+            classLoader.loadClass(rubricProviderClassName).getConstructor().newInstance() as RubricProvider
+        } catch (e: Throwable) {
+            logger.error("Failed to initialize rubricProvider $rubricProviderClassName for $submission", e)
+            return null
         }
-        return result
+        val exportFileName = rubricProvider.getOutputFileName(submission) ?: submission.info.toString()
+        return rubricProvider.rubric.grade(this) to exportFileName
     }
 }

--- a/grader-api/src/main/java/org/sourcegrade/jagr/api/rubric/RubricForSubmission.java
+++ b/grader-api/src/main/java/org/sourcegrade/jagr/api/rubric/RubricForSubmission.java
@@ -27,8 +27,11 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * This annotation is used to mark a class as a rubric provider for a submission.
+ * This annotation is used to mark a class as a {@link RubricProvider} for a submission.
+ *
+ * @deprecated This annotation is no longer used by Jagr, the {@link RubricProvider}'s class name is provided via the generated grader-info.json
  */
+@Deprecated(forRemoval = true)
 @ApiStatus.NonExtendable
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)

--- a/grader-api/src/main/java/org/sourcegrade/jagr/api/rubric/RubricForSubmission.java
+++ b/grader-api/src/main/java/org/sourcegrade/jagr/api/rubric/RubricForSubmission.java
@@ -29,7 +29,8 @@ import java.lang.annotation.Target;
 /**
  * This annotation is used to mark a class as a {@link RubricProvider} for a submission.
  *
- * @deprecated This annotation is no longer used by Jagr, the {@link RubricProvider}'s class name is provided via the generated grader-info.json
+ * @deprecated This annotation is no longer used by Jagr, the {@link RubricProvider}'s
+ * class name is provided via the generated grader-info.json
  */
 @Deprecated(forRemoval = true)
 @ApiStatus.NonExtendable

--- a/grader-api/src/main/java/org/sourcegrade/jagr/api/rubric/RubricForSubmission.java
+++ b/grader-api/src/main/java/org/sourcegrade/jagr/api/rubric/RubricForSubmission.java
@@ -29,8 +29,7 @@ import java.lang.annotation.Target;
 /**
  * This annotation is used to mark a class as a {@link RubricProvider} for a submission.
  *
- * @deprecated This annotation is no longer used by Jagr, the {@link RubricProvider}'s
- * class name is provided via the generated grader-info.json
+ * @deprecated This annotation is no longer used by Jagr as the class name is provided via the generated grader-info.json
  */
 @Deprecated(forRemoval = true)
 @ApiStatus.NonExtendable

--- a/grader-api/src/main/java/org/sourcegrade/jagr/api/rubric/TestForSubmission.java
+++ b/grader-api/src/main/java/org/sourcegrade/jagr/api/rubric/TestForSubmission.java
@@ -38,6 +38,8 @@ public @interface TestForSubmission {
      * The assignment id of the submission.
      *
      * @return The assignment id of the submission
+     * @deprecated No longer read by Jagr, the assignmentId is provided via the generated grader-info.json
      */
-    String value();
+    @Deprecated(forRemoval = true)
+    String value() default "";
 }

--- a/grader-api/src/main/java/org/sourcegrade/jagr/api/testing/TestCycle.java
+++ b/grader-api/src/main/java/org/sourcegrade/jagr/api/testing/TestCycle.java
@@ -44,7 +44,7 @@ public interface TestCycle {
      *
      * @return The class name of the rubric provider in this test cycle
      */
-    String getRubricProviderClassName();
+    String getRubricProviderName();
 
     /**
      * Every test cycle uses a unique {@link ClassLoader} that loads the grader jar's classes and the {@link Submission}'s

--- a/grader-api/src/main/java/org/sourcegrade/jagr/api/testing/TestCycle.java
+++ b/grader-api/src/main/java/org/sourcegrade/jagr/api/testing/TestCycle.java
@@ -40,11 +40,11 @@ import java.util.List;
 public interface TestCycle {
 
     /**
-     * The class names of every rubric provider in this test cycle.
+     * The class name of the rubric provider in this test cycle.
      *
-     * @return An immutable set of class names
+     * @return The class name of the rubric provider in this test cycle
      */
-    List<String> getRubricProviderClassNames();
+    String getRubricProviderClassName();
 
     /**
      * Every test cycle uses a unique {@link ClassLoader} that loads the grader jar's classes and the {@link Submission}'s

--- a/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/extension/GraderConfiguration.kt
+++ b/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/extension/GraderConfiguration.kt
@@ -40,6 +40,7 @@ abstract class GraderConfiguration(
         .convention(listOf(name))
 
     abstract val graderName: Property<String>
+    abstract val rubricClassName: Property<String>
     val parentConfiguration: Property<GraderConfiguration> = project.objects.property()
 
     private val submissionConfigurationConvention = parentConfiguration.flatMap { it.submissionConfiguration }

--- a/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/extension/GraderConfiguration.kt
+++ b/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/extension/GraderConfiguration.kt
@@ -40,7 +40,7 @@ abstract class GraderConfiguration(
         .convention(listOf(name))
 
     abstract val graderName: Property<String>
-    abstract val rubricClassName: Property<String>
+    abstract val rubricProviderName: Property<String>
     val parentConfiguration: Property<GraderConfiguration> = project.objects.property()
 
     private val submissionConfigurationConvention = parentConfiguration.flatMap { it.submissionConfiguration }

--- a/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/task/grader/GraderWriteInfoTask.kt
+++ b/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/task/grader/GraderWriteInfoTask.kt
@@ -30,7 +30,7 @@ abstract class GraderWriteInfoTask : DefaultTask(), GraderTask {
 
     @get:Input
     @get:Optional
-    abstract val rubricClassName: Property<String>
+    abstract val rubricProviderName: Property<String>
 
     @get:Input
     val graderFiles: ListProperty<String> = project.objects.listProperty<String>().value(
@@ -67,13 +67,15 @@ abstract class GraderWriteInfoTask : DefaultTask(), GraderTask {
         return result
     }
 
-    private fun GraderConfiguration.getRubricClassNameRecursive(): String {
-        return if (rubricClassName.isPresent) {
-            rubricClassName.get()
+    private fun GraderConfiguration.getRubricProviderNameRecursive(): String {
+        return if (rubricProviderName.isPresent) {
+            rubricProviderName.get()
         } else if (parentConfiguration.isPresent) {
-            parentConfiguration.get().getRubricClassNameRecursive()
+            parentConfiguration.get().getRubricProviderNameRecursive()
         } else {
-            throw GradleException("No rubric class name found for configuration $name")
+            throw GradleException(
+                "No rubricProviderName defined for grader configuration ${configurationName.get()} or its parents"
+            )
         }
     }
 
@@ -84,7 +86,7 @@ abstract class GraderWriteInfoTask : DefaultTask(), GraderTask {
             assignmentId.get(),
             Jagr.version,
             graderName.get(),
-            rubricClassName.getOrElse(jagr.graders[configurationName.get()].getRubricClassNameRecursive()),
+            rubricProviderName.getOrElse(jagr.graders[configurationName.get()].getRubricProviderNameRecursive()),
             listOf(
                 SourceSetInfo("grader", graderFiles.get()),
                 SourceSetInfo("solution", solutionFiles.get())
@@ -100,7 +102,7 @@ abstract class GraderWriteInfoTask : DefaultTask(), GraderTask {
         override fun determineTaskName(name: String) = "${name}WriteGraderInfo"
         override fun configureTask(task: GraderWriteInfoTask, project: Project, configuration: GraderConfiguration) {
             task.description = "Runs the ${task.sourceSetNames.get()} grader"
-            task.rubricClassName.set(configuration.rubricClassName)
+            task.rubricProviderName.set(configuration.rubricProviderName)
         }
     }
 }

--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/io/GraderInfo.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/io/GraderInfo.kt
@@ -32,10 +32,12 @@ data class GraderInfo(
     val assignmentId: String,
     val jagrVersion: String,
     val name: String,
+    val rubricClassName: String,
     val sourceSets: List<SourceSetInfo>,
 ) {
     companion object Factory : SerializerFactory<GraderInfo> {
         override fun read(scope: SerializationScope.Input) = GraderInfo(
+            scope.input.readUTF(),
             scope.input.readUTF(),
             scope.input.readUTF(),
             scope.input.readUTF(),
@@ -45,6 +47,7 @@ data class GraderInfo(
         override fun write(obj: GraderInfo, scope: SerializationScope.Output) {
             scope.output.writeUTF(obj.assignmentId)
             scope.output.writeUTF(obj.jagrVersion)
+            scope.output.writeUTF(obj.rubricClassName)
             scope.output.writeUTF(obj.name)
             scope.writeList(obj.sourceSets)
         }

--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/io/GraderInfo.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/io/GraderInfo.kt
@@ -32,7 +32,7 @@ data class GraderInfo(
     val assignmentId: String,
     val jagrVersion: String,
     val name: String,
-    val rubricClassName: String,
+    val rubricProviderName: String,
     val sourceSets: List<SourceSetInfo>,
 ) {
     companion object Factory : SerializerFactory<GraderInfo> {
@@ -48,7 +48,7 @@ data class GraderInfo(
             scope.output.writeUTF(obj.assignmentId)
             scope.output.writeUTF(obj.jagrVersion)
             scope.output.writeUTF(obj.name)
-            scope.output.writeUTF(obj.rubricClassName)
+            scope.output.writeUTF(obj.rubricProviderName)
             scope.writeList(obj.sourceSets)
         }
     }

--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/io/GraderInfo.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/io/GraderInfo.kt
@@ -47,8 +47,8 @@ data class GraderInfo(
         override fun write(obj: GraderInfo, scope: SerializationScope.Output) {
             scope.output.writeUTF(obj.assignmentId)
             scope.output.writeUTF(obj.jagrVersion)
-            scope.output.writeUTF(obj.rubricClassName)
             scope.output.writeUTF(obj.name)
+            scope.output.writeUTF(obj.rubricClassName)
             scope.writeList(obj.sourceSets)
         }
     }

--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/io/GraderJar.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/io/GraderJar.kt
@@ -24,6 +24,5 @@ import org.sourcegrade.jagr.api.testing.RubricConfiguration
 interface GraderJar {
     val info: GraderInfo
     val configuration: RubricConfiguration
-    val rubricProviders: Map<String, List<String>>
-    val testProviders: Map<String, List<String>>
+    val testClassNames: List<String>
 }


### PR DESCRIPTION
Add the property `rubricClassName` to the `grader-info.json` for a grader and deprecate the annotation `@RubricForSubmission` as it is redundant now. Additionally, deprecate the `String value()` attribute for the annotation `@TestForSubmission` as the assignmentId is also specified via the `grader-info.json`.

This change comes from the move to a single assignmentId per grader, which was started in #101.