### PR TITLE
Add visitClass to RuntimeClassLoader

### DIFF
--- a/grader-api/src/main/java/org/sourcegrade/jagr/api/testing/RuntimeClassLoader.java
+++ b/grader-api/src/main/java/org/sourcegrade/jagr/api/testing/RuntimeClassLoader.java
@@ -61,6 +61,22 @@ public interface RuntimeClassLoader {
     Class<?> loadClass(String name, Iterable<? extends ClassTransformer> transformers);
 
     /**
+     * Loads and visits the class with the specified name with the provided transformers.
+     *
+     * @param name         The name of the class to load
+     * @param transformers The transformers to apply to the class
+     */
+    void visitClass(String name, ClassTransformer... transformers);
+
+    /**
+     * Loads and visits the class with the specified name with the provided transformers.
+     *
+     * @param name         The name of the class to load
+     * @param transformers The transformers to apply to the class
+     */
+    void visitClass(String name, Iterable<? extends ClassTransformer> transformers);
+
+    /**
      * The names of all classes in this submission.
      *
      * @return The names of all classes in this submission


### PR DESCRIPTION
For cases where it is not necessary to return a new class object, only visit the class without defining a new one.