### PR TITLE
Improve sourceSets in grader and submission info json

### DIFF
--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/GraderJarImpl.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/GraderJarImpl.kt
@@ -50,8 +50,8 @@ class GraderJarImpl(
      */
     override val testClassNames: List<String>
 
-    private val graderFiles = info.graderFiles.toSet()
-    private val solutionFiles = info.solutionFiles.toSet()
+    private val graderFiles = info.graderFiles
+    private val solutionFiles = info.solutionFiles
 
     val containerWithoutSolution = container.copy(
         source = container.source.copy(

--- a/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/SourceSetExtensions.kt
+++ b/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/SourceSetExtensions.kt
@@ -21,18 +21,18 @@ package org.sourcegrade.jagr.gradle
 
 import org.gradle.api.tasks.SourceSet
 
-internal fun SourceSet.forEachFile(action: (String) -> Unit) {
-    return allSource.files.forEach { file ->
-        allSource.srcDirs.asSequence()
-            .map(file::relativeTo)
-            .reduce { a, b -> if (a.path.length < b.path.length) a else b }
-            .path
-            .apply(action)
+internal fun SourceSet.forEachFile(action: (directorySet: String, fileName: String) -> Unit) {
+    for (directorySet in allSource.sourceDirectories) {
+        for (file in directorySet.walkTopDown()) {
+            if (file.isFile) {
+                action(directorySet.name, file.relativeTo(directorySet).path)
+            }
+        }
     }
 }
 
-internal fun SourceSet.getFiles(): List<String> {
-    val result = mutableListOf<String>()
-    forEachFile { result.add(it) }
+internal fun SourceSet.getFiles(): Map<String, Set<String>> {
+    val result = mutableMapOf<String, MutableSet<String>>()
+    forEachFile { directorySet, fileName -> result.computeIfAbsent(directorySet) { mutableSetOf() }.add(fileName) }
     return result
 }

--- a/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/extension/AbstractConfiguration.kt
+++ b/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/extension/AbstractConfiguration.kt
@@ -61,18 +61,18 @@ abstract class AbstractConfiguration(
         }
     }
 
-    private fun getConfiguration(configurationName: String, normalizedName: String?): Pair<String, List<String>>? {
+    private fun getConfiguration(configurationName: String, normalizedName: String?): Pair<String, Set<String>>? {
         return project.configurations.findByName(configurationName)?.let { configuration ->
-            val dependencies = configuration.dependencies.map { "${it.group}:${it.name}:${it.version}" }
+            val dependencies = configuration.dependencies.mapTo(mutableSetOf()) { "${it.group}:${it.name}:${it.version}" }
                 .takeIf { it.isNotEmpty() } ?: return null
             (normalizedName ?: configurationName) to dependencies
         }
     }
 
     @JvmOverloads
-    internal fun getAllDependencies(normalizedName: String? = null): Map<String, List<String>> {
+    internal fun getAllDependencies(normalizedName: String? = null): Map<String, Set<String>> {
         return sourceSets.flatMap { sourceSet ->
-            listOfNotNull(
+            setOfNotNull(
                 getConfiguration(sourceSet.apiConfigurationName, normalizedName?.let { "${it}Api" }),
                 getConfiguration(sourceSet.compileOnlyConfigurationName, normalizedName?.let { "${it}CompileOnly" }),
                 getConfiguration(sourceSet.compileOnlyApiConfigurationName, normalizedName?.let { "${it}CompileOnlyApi" }),

--- a/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/task/grader/GraderWriteInfoTask.kt
+++ b/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/task/grader/GraderWriteInfoTask.kt
@@ -65,9 +65,7 @@ abstract class GraderWriteInfoTask : WriteInfoTask(), GraderTask {
         val result = mutableMapOf<String, MutableSet<String>>()
         sourceSets.forEach { sourceSet ->
             sourceSet.forEachFile { directorySet, fileName ->
-                result.computeIfAbsent(directorySet) { mutableSetOf() }.let { list ->
-                    if (fileName !in list) list.add(fileName)
-                }
+                result.computeIfAbsent(directorySet) { mutableSetOf() }.add(fileName)
             }
         }
         // technically this is a race condition, but we can't use Provider.zip because the value is not always configured

--- a/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/task/grader/GraderWriteInfoTask.kt
+++ b/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/task/grader/GraderWriteInfoTask.kt
@@ -4,7 +4,6 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.gradle.api.GradleException
 import org.gradle.api.Project
-import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
@@ -13,7 +12,6 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.getByType
-import org.gradle.kotlin.dsl.listProperty
 import org.gradle.kotlin.dsl.mapProperty
 import org.gradle.kotlin.dsl.property
 import org.sourcegrade.jagr.gradle.extension.GraderConfiguration
@@ -39,17 +37,18 @@ abstract class GraderWriteInfoTask : WriteInfoTask(), GraderTask {
     abstract val rubricProviderName: Property<String>
 
     @get:Input
-    val graderFiles: ListProperty<String> = project.objects.listProperty<String>().value(
+    val graderFiles: MapProperty<String, Set<String>> = project.objects.mapProperty<String, Set<String>>().value(
         configurationName.map { c -> primaryContainer[c].getFilesRecursive() }
     )
 
     @get:Input
-    val solutionFiles: MapProperty<String, List<String>> = project.objects.mapProperty<String, List<String>>().value(
-        solutionConfigurationName.map { c -> submissionContainer[c].sourceSets.associate { it.name to it.getFiles() } }
-    )
+    val solutionFiles: MapProperty<String, Map<String, Set<String>>> =
+        project.objects.mapProperty<String, Map<String, Set<String>>>().value(
+            solutionConfigurationName.map { c -> submissionContainer[c].sourceSets.associate { it.name to it.getFiles() } }
+        )
 
     @get:Input
-    val dependencies: MapProperty<String, List<String>> = project.objects.mapProperty<String, List<String>>().value(
+    val dependencies: MapProperty<String, Set<String>> = project.objects.mapProperty<String, Set<String>>().value(
         configurationName.map { c -> primaryContainer[c].getAllDependenciesRecursive() }
     )
 
@@ -62,19 +61,25 @@ abstract class GraderWriteInfoTask : WriteInfoTask(), GraderTask {
         dependsOn("compileJava")
     }
 
-    private fun GraderConfiguration.getFilesRecursive(): List<String> {
-        val result = mutableListOf<String>()
+    private fun GraderConfiguration.getFilesRecursive(): Map<String, Set<String>> {
+        val result = mutableMapOf<String, MutableSet<String>>()
         sourceSets.forEach { sourceSet ->
-            sourceSet.forEachFile { result.add(it) }
+            sourceSet.forEachFile { directorySet, fileName ->
+                result.computeIfAbsent(directorySet) { mutableSetOf() }.let { list ->
+                    if (fileName !in list) list.add(fileName)
+                }
+            }
         }
         // technically this is a race condition, but we can't use Provider.zip because the value is not always configured
         if (parentConfiguration.isPresent) {
-            result.addAll(parentConfiguration.get().getFilesRecursive())
+            parentConfiguration.get().getFilesRecursive().forEach { (directorySet, files) ->
+                result.computeIfAbsent(directorySet) { mutableSetOf() }.addAll(files)
+            }
         }
         return result
     }
 
-    private fun GraderConfiguration.getAllDependenciesRecursive(): Map<String, List<String>> {
+    private fun GraderConfiguration.getAllDependenciesRecursive(): Map<String, Set<String>> {
         val ownDependencies = getAllDependencies("grader") +
             solutionConfiguration.get().getAllDependencies()
         return if (parentConfiguration.isPresent) {

--- a/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/task/submission/SubmissionWriteInfoTask.kt
+++ b/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/task/submission/SubmissionWriteInfoTask.kt
@@ -30,14 +30,12 @@ abstract class SubmissionWriteInfoTask : WriteInfoTask(), SubmissionTask {
     private val primaryContainer = project.extensions.getByType<JagrExtension>().submissions
 
     @get:Input
-    val sourceSetFiles: MapProperty<String, List<String>> = project.objects.mapProperty<String, List<String>>().value(
-        configurationName.map { c -> primaryContainer[c].sourceSets.associate { it.name to it.getFiles() } }
-    )
+    val files: MapProperty<String, Map<String, Set<String>>> = project.objects.mapProperty<String, Map<String, Set<String>>>()
+        .value(configurationName.map { c -> primaryContainer[c].sourceSets.associate { it.name to it.getFiles() } })
 
     @get:Input
-    val dependencies: MapProperty<String, List<String>> = project.objects.mapProperty<String, List<String>>().value(
-        configurationName.map { c -> primaryContainer[c].getAllDependencies() }
-    )
+    val dependencies: MapProperty<String, Set<String>> = project.objects.mapProperty<String, Set<String>>()
+        .value(configurationName.map { c -> primaryContainer[c].getAllDependencies() })
 
     @get:OutputFile
     val submissionInfoFile: Property<File> = project.objects.property<File>()
@@ -74,7 +72,7 @@ $errors
         val submissionInfo = SubmissionInfo(
             assignmentId.get(),
             Jagr.version,
-            sourceSetFiles.get().map { SourceSetInfo(it.key, it.value) },
+            files.get().map { SourceSetInfo(it.key, it.value) },
             dependencies.get(),
             repositories.get().map { RepositoryConfiguration(it.first, it.second) },
             studentId.get(),

--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/io/AssignmentArtifactInfo.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/io/AssignmentArtifactInfo.kt
@@ -23,6 +23,6 @@ interface AssignmentArtifactInfo {
     val assignmentId: String
     val jagrVersion: String
     val sourceSets: List<SourceSetInfo>
-    val dependencyConfigurations: Map<String, List<String>>
+    val dependencyConfigurations: Map<String, Set<String>>
     val repositoryConfigurations: List<RepositoryConfiguration>
 }

--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/io/GraderInfo.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/io/GraderInfo.kt
@@ -32,7 +32,7 @@ data class GraderInfo(
     override val assignmentId: String,
     override val jagrVersion: String,
     override val sourceSets: List<SourceSetInfo>,
-    override val dependencyConfigurations: Map<String, List<String>>,
+    override val dependencyConfigurations: Map<String, Set<String>>,
     override val repositoryConfigurations: List<RepositoryConfiguration>,
     val name: String,
     val rubricProviderName: String,
@@ -60,14 +60,14 @@ data class GraderInfo(
     }
 }
 
-val GraderInfo.graderFiles: List<String> by named("grader")
+val GraderInfo.graderFiles: Set<String> by named("grader")
 
-val GraderInfo.mainFiles: List<String> by named("main")
+val GraderInfo.mainFiles: Set<String> by named("main")
 
-val GraderInfo.testFiles: List<String> by named("test")
+val GraderInfo.testFiles: Set<String> by named("test")
 
-val GraderInfo.solutionFiles: List<String>
+val GraderInfo.solutionFiles: Set<String>
     get() = mainFiles + testFiles
 
-private fun named(name: String): ReadOnlyProperty<GraderInfo, List<String>> =
-    ReadOnlyProperty { info, _ -> info.sourceSets.first { it.name == name }.files }
+private fun named(name: String): ReadOnlyProperty<GraderInfo, Set<String>> =
+    ReadOnlyProperty { info, _ -> info.sourceSets.first { it.name == name }.files.flatMapTo(mutableSetOf()) { it.value } }

--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/io/SourceSetInfo.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/io/SourceSetInfo.kt
@@ -24,14 +24,14 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class SourceSetInfo(
     val name: String,
-    val files: List<String>,
+    val files: Map<String, Set<String>>,
 ) {
     companion object Factory : SerializerFactory<SourceSetInfo> {
-        override fun read(scope: SerializationScope.Input) = SourceSetInfo(scope.input.readUTF(), scope.readList())
+        override fun read(scope: SerializationScope.Input) = SourceSetInfo(scope.input.readUTF(), scope.readMap())
 
         override fun write(obj: SourceSetInfo, scope: SerializationScope.Output) {
             scope.output.writeUTF(obj.name)
-            scope.writeList(obj.files)
+            scope.writeMap(obj.files)
         }
     }
 }

--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/io/SubmissionInfo.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/io/SubmissionInfo.kt
@@ -31,7 +31,7 @@ data class SubmissionInfo(
     override val assignmentId: String,
     override val jagrVersion: String,
     override val sourceSets: List<SourceSetInfo>,
-    override val dependencyConfigurations: Map<String, List<String>>,
+    override val dependencyConfigurations: Map<String, Set<String>>,
     override val repositoryConfigurations: List<RepositoryConfiguration>,
     val studentId: String,
     val firstName: String,


### PR DESCRIPTION
Before:
```json
"sourceSets": [
    {
      "name": "grader",
      "files": [
        "solutionbar.txt",
        "h00/H00_RubricProvider.java",
        "h00/TutorTests.java",
      ]
    },
    {
      "name": "main",
      "files": [
        "h00/Main.java",
        "studentbar.txt"
      ]
    },
    {
      "name": "test",
      "files": [
        "h00/ExampleJUnitTest.java"
      ]
    }
  ],
  ```
  After:
  ```json
   "sourceSets": [
    {
      "name": "grader",
      "files": {
        "resources": [
          "solutionbar.txt"
        ],
        "java": [
          "h00/H00_RubricProvider.java",
          "h00/TutorTests.java"
        ]
      }
    },
    {
      "name": "main",
      "files": {
        "resources": [
          "studentbar.txt"
        ],
        "java": [
          "h00/Main.java"
        ]
      }
    },
    {
      "name": "test",
      "files": {
        "java": [
          "h00/ExampleJUnitTest.java"
        ]
      }
    }
  ],
  ```