### PR TITLE
Fix broken capitalization in some locals by forcing english capitalization

### DIFF
--- a/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/extension/AbstractConfiguration.kt
+++ b/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/extension/AbstractConfiguration.kt
@@ -23,9 +23,9 @@ import org.gradle.api.Project
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
-import org.gradle.configurationcache.extensions.capitalized
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.getByType
+import java.util.Locale
 
 abstract class AbstractConfiguration(
     val name: String,
@@ -53,7 +53,9 @@ abstract class AbstractConfiguration(
     private fun SourceSet.initialize(project: Project) {
         project.dependencies {
             for ((suffix, dependencyNotations) in dependencyConfiguration.dependencies) {
-                val configurationName = if (name == "main") suffix else "$name${suffix.capitalized()}"
+                val configurationName = if (name == "main") suffix else {
+                    "$name${suffix.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.ENGLISH) else it.toString() }}"
+                }
                 for (dependencyNotation in dependencyNotations) {
                     add(configurationName, dependencyNotation)
                 }


### PR DESCRIPTION
In some locales, the `org.gradle.configurationcache.extensions.capitalized` method causes configuration names to be incorrectly capitalized. For example, `"implementation".capitalized()` may become `?mplementation`.

This PR forces the English capitalization of the configuration suffix.