### PR TITLE
Make the link to the result.html file clickable inside the console on Windows

### DIFF
--- a/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/task/grader/GraderRunTask.kt
+++ b/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/task/grader/GraderRunTask.kt
@@ -38,6 +38,7 @@ import org.sourcegrade.jagr.launcher.io.logGradedRubric
 import org.sourcegrade.jagr.launcher.io.logHistogram
 import org.sourcegrade.jagr.launcher.io.writeIn
 import java.io.File
+import java.net.URI
 
 @Suppress("LeakingThis")
 abstract class GraderRunTask : DefaultTask(), GraderTask {
@@ -174,7 +175,7 @@ abstract class GraderRunTask : DefaultTask(), GraderTask {
         } else {
             jagr.logger.info("Exported $rubricCount rubrics")
         }
-        val rubricLocation = "file://${rubricOutputDir.absolutePath}/result.html"
+        val rubricLocation = URI("file", "", rubricOutputDir.toURI().path + "result.html", null, null).toString()
         jagr.logger.info("See rubric at $rubricLocation")
         if (failed) {
             throw GradleException("Grading failed! See the rubric at $rubricLocation")


### PR DESCRIPTION
When the task GraderPublicRun fails the link to the file containing the grading result isn't always clickable inside the console on windows.

This PR fixes this behavior by using URI#toString() to create the link.