### PR TITLE
Check child tests for failtures

### DIFF
--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/rubric/JUnitTestRefFactoryImpl.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/rubric/JUnitTestRefFactoryImpl.kt
@@ -93,19 +93,12 @@ class JUnitTestRefFactoryImpl @Inject constructor(
         inner class TestNotFoundError : AssertionFailedError("Test result not found")
 
         override operator fun get(testResults: Map<TestIdentifier, TestExecutionResult>): TestExecutionResult {
-            val applicableTestResults: List<TestExecutionResult> = testResults
-                .filter { (identifier, _) -> testSource == identifier.source.orElse(null) }
-                .map { (_, result) -> result }
-            return if (applicableTestResults.isEmpty()) {
-                TestExecutionResult.failed(TestNotFoundError())
-            } else {
-                val failedTests = applicableTestResults.filter { it.status == TestExecutionResult.Status.FAILED }
-                if (failedTests.isNotEmpty()) {
-                    failedTests.first()
-                } else {
-                    TestExecutionResult.successful()
+            for ((identifier, result) in testResults) {
+                if (testSource == identifier.source.orElse(null)) {
+                    return result
                 }
             }
+            return TestExecutionResult.failed(TestNotFoundError())
         }
     }
 

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/rubric/JUnitTestRefFactoryImpl.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/rubric/JUnitTestRefFactoryImpl.kt
@@ -93,15 +93,24 @@ class JUnitTestRefFactoryImpl @Inject constructor(
         inner class TestNotFoundError : AssertionFailedError("Test result not found")
 
         override operator fun get(testResults: Map<TestIdentifier, TestExecutionResult>): TestExecutionResult {
-            val applicableTestResults: List<TestExecutionResult> = testResults
-                .filter { (identifier, _) -> testSource == identifier.source.orElse(null) }
-                .map { (_, result) -> result }
-            return if (applicableTestResults.isEmpty()) {
-                TestExecutionResult.failed(TestNotFoundError())
+            val applicableTestResults: Map<TestIdentifier, TestExecutionResult> = testResults
+                .filter { (id, _) -> testSource == id.source.orElse(null) }
+                .toMap()
+            if (applicableTestResults.isEmpty()) {
+                return TestExecutionResult.failed(TestNotFoundError())
             } else {
-                val failedTests = applicableTestResults.filter { it.status == TestExecutionResult.Status.FAILED }
-                if (failedTests.isNotEmpty()) {
-                    failedTests.first()
+                // first search for a failed container, then a failed child test
+                val failedContainer = applicableTestResults.entries.find { (id, result) ->
+                    result.status == TestExecutionResult.Status.FAILED && id.type.isContainer
+                }
+                if (failedContainer != null) {
+                    return failedContainer.value
+                }
+                val failedTests = applicableTestResults.entries.filter { (_, result) ->
+                    result.status == TestExecutionResult.Status.FAILED
+                }
+                return if (failedTests.isNotEmpty()) {
+                    failedTests.first().value
                 } else {
                     TestExecutionResult.successful()
                 }

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/rubric/JUnitTestRefFactoryImpl.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/rubric/JUnitTestRefFactoryImpl.kt
@@ -93,12 +93,19 @@ class JUnitTestRefFactoryImpl @Inject constructor(
         inner class TestNotFoundError : AssertionFailedError("Test result not found")
 
         override operator fun get(testResults: Map<TestIdentifier, TestExecutionResult>): TestExecutionResult {
-            for ((identifier, result) in testResults) {
-                if (testSource == identifier.source.orElse(null)) {
-                    return result
+            val applicableTestResults: List<TestExecutionResult> = testResults
+                .filter { (identifier, _) -> testSource == identifier.source.orElse(null) }
+                .map { (_, result) -> result }
+            return if (applicableTestResults.isEmpty()) {
+                TestExecutionResult.failed(TestNotFoundError())
+            } else {
+                val failedTests = applicableTestResults.filter { it.status == TestExecutionResult.Status.FAILED }
+                if (failedTests.isNotEmpty()) {
+                    failedTests.first()
+                } else {
+                    TestExecutionResult.successful()
                 }
             }
-            return TestExecutionResult.failed(TestNotFoundError())
         }
     }
 

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/TestStatusListenerImpl.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/TestStatusListenerImpl.kt
@@ -23,19 +23,27 @@ import org.apache.logging.log4j.Logger
 import org.junit.platform.engine.TestExecutionResult
 import org.junit.platform.launcher.TestExecutionListener
 import org.junit.platform.launcher.TestIdentifier
+import org.junit.platform.launcher.TestPlan
+import org.opentest4j.AssertionFailedError
 import org.sourcegrade.jagr.api.testing.TestStatusListener
 import org.sourcegrade.jagr.launcher.io.SubmissionInfo
 import java.util.Collections
 
-class TestStatusListenerImpl(
+internal class TestStatusListenerImpl(
     private val logger: Logger,
 ) : TestExecutionListener, TestStatusListener {
 
     private val testResults: MutableMap<TestIdentifier, TestExecutionResult> = mutableMapOf()
     private val linkageErrors: MutableSet<Pair<String?, String>> = LinkedHashSet()
+    private lateinit var testPlan: TestPlan
+
+    override fun testPlanExecutionStarted(testPlan: TestPlan) {
+        this.testPlan = testPlan
+        testResults.clear()
+    }
 
     override fun executionFinished(testIdentifier: TestIdentifier, testExecutionResult: TestExecutionResult) {
-        testResults[testIdentifier] = testExecutionResult
+        testResults[testIdentifier] = aggregate(testIdentifier, testExecutionResult)
         testExecutionResult.throwable.orElse(null)?.also { throwable ->
             if (throwable is LinkageError) {
                 linkageErrors.add(throwable::class.simpleName to throwable.message + " @ " + throwable.stackTrace.firstOrNull())
@@ -43,11 +51,33 @@ class TestStatusListenerImpl(
         }
     }
 
-    fun logLinkageErrors(info: SubmissionInfo) {
+    private fun aggregate(testIdentifier: TestIdentifier, parentResult: TestExecutionResult): TestExecutionResult {
+        if (parentResult.status == TestExecutionResult.Status.FAILED) {
+            return parentResult
+        }
+        val failedChildren: Map<TestIdentifier, TestExecutionResult> = testPlan.getDescendants(testIdentifier).asSequence()
+            .map { it to testResults[it] }
+            .filter { (_, result) -> result != null && result.status != TestExecutionResult.Status.SUCCESSFUL }
+            .map { (identifier, result) -> identifier to result!! }
+            .toMap()
+        if (failedChildren.isEmpty()) {
+            return parentResult
+        }
+        return TestExecutionResult.failed(ContainerFailedError(failedChildren))
+    }
+
+    internal fun logLinkageErrors(info: SubmissionInfo) {
         for (errorMessage in linkageErrors) {
             logger.error("Linkage error @ $info :: $errorMessage")
         }
     }
 
     override fun getTestResults(): Map<TestIdentifier, TestExecutionResult> = Collections.unmodifiableMap(testResults)
+
+    private class ContainerFailedError(
+        failedChildren: Map<TestIdentifier, TestExecutionResult>,
+    ) : AssertionFailedError(
+        "There were failing tests in this container:\n" +
+            failedChildren.entries.joinToString("\n") { (identifier, result) -> "$identifier: $result" }
+    )
 }

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/TestStatusListenerImpl.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/testing/TestStatusListenerImpl.kt
@@ -77,7 +77,10 @@ internal class TestStatusListenerImpl(
     private class ContainerFailedError(
         failedChildren: Map<TestIdentifier, TestExecutionResult>,
     ) : AssertionFailedError(
-        "There were failing tests in this container:\n" +
-            failedChildren.entries.joinToString("\n") { (identifier, result) -> "$identifier: $result" }
+        failedChildren.entries.first().value.throwable.orElse(null)?.message + when (failedChildren.size) {
+            1 -> ""
+            2 -> "\n\nthere is 1 more failing test"
+            else -> "\n\nthere are ${failedChildren.size - 1} more failing tests"
+        }
     )
 }


### PR DESCRIPTION
Supercedes #144 and #143 and fixes #142 and #140.

This is a more efficient approach than #144 in that it does not perform an O(n^2) search of all test results on every access.

Instead, aggregate the results on collection to directly fail containers if child tests failed.