### PR TITLE
Fix Windows file separator shenanigans

### DIFF
--- a/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/SourceSetExtensions.kt
+++ b/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/SourceSetExtensions.kt
@@ -25,7 +25,7 @@ internal fun SourceSet.forEachFile(action: (directorySet: String, fileName: Stri
     for (directorySet in allSource.sourceDirectories) {
         for (file in directorySet.walkTopDown()) {
             if (file.isFile) {
-                action(directorySet.name, file.relativeTo(directorySet).invariantSeparatorsPath)
+                action(directorySet.name, file.relativeTo(directorySet).path.replace("\\", "/"))
             }
         }
     }


### PR DESCRIPTION
Windows is being special once again so just replace backslashes in path with forward-facing slashes