### PR TITLE
Fix ClassRenamingTransformer not renaming locals in frames

### DIFF
--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/transformer/ClassRenamingTransformer.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/transformer/ClassRenamingTransformer.kt
@@ -85,8 +85,8 @@ class ClassRenamingTransformer(
 
             override fun visitFrame(type: Int, numLocal: Int, local: Array<out Any>, numStack: Int, stack: Array<out Any>) {
                 // local and stack frames must be updated to reflect the new classname
-                val newLocal = local.map { if (it is String && it == oldName) newName else it }.toTypedArray()
-                val newStack = stack.map { if (it is String && it == oldName) newName else it }.toTypedArray()
+                val newLocal = Array(local.size) { i -> local[i].let { if (it == oldName) newName else it } }
+                val newStack = Array(stack.size) { i -> stack[i].let { if (it == oldName) newName else it } }
                 super.visitFrame(type, numLocal, newLocal, numStack, newStack)
             }
         }


### PR DESCRIPTION
Fixes the VerifyError caused by classes renamed by the `ClassRenamingTransformer`.

The following code works, as there are only three extra locals defined.

Java:
```java
    public void addToDirectionOfOffspring(int m) {
        int a = 0;
        int b = 0;
        int c = 0;
        if (m < 0) {
        }
    }
```

Bytecode:
```bytecode
...
   L4
    LINENUMBER 24 L4
   FRAME APPEND [I I I]
    RETURN
    MAXSTACK = 1
    MAXLOCALS = 5
...
```

The `FRAME APPEND [I I I]` is used here, because there are (up to) 3 new locals in the frame. This does not result in an error.

However, adding one more local variable like this:

Java:
```java
    public void addToDirectionOfOffspring(int m) {
        int a = 0;
        int b = 0;
        int c = 0;
        int d = 0;
        if (m < 0) {
        }
    }
```

Results in the following bytecode:
```bytecode
   L5
    LINENUMBER 24 L5
   FRAME FULL [h03/RobotWithOffspring I I I I I] []
    RETURN
    MAXSTACK = 1
    MAXLOCALS = 6
```

This happens because the frame must be defined in full, instead of as a delta of the previous frame as there are more than 3 new locals. This results in the following error:

```
java.lang.VerifyError: Inconsistent stackmap frames at branch target 21
Exception Details:
Location:
h03/RobotWithOffspring_160194246900638.addToDirectionOfOffspring(ILh03/RobotWithOffspring;)V @21: return
Reason:
Type 'h03/RobotWithOffspring_160194246900638' (current frame, locals[0]) is not assignable to 'h03/RobotWithOffspring' (stack map, locals[0])
Current Frame:
bci: @18
flags: { }
locals: { 'h03/RobotWithOffspring_160194246900638', integer, 'h03/RobotWithOffspring', integer, integer, integer, integer }
stack: { integer }
Stackmap Frame:
bci: @21
flags: { }
locals: { 'h03/RobotWithOffspring', integer, 'h03/RobotWithOffspring', integer, integer, integer, integer }
stack: { }
Bytecode:
0000000: b800 1e03 3e03 3604 0336 0503 3606 1bb8
0000010: 001e 9c00 03b1
Stackmap Table:
full_frame(@21,{Object[#8],Integer,Object[#8],Integer,Integer,Integer,Integer},{})
```

The type of the 0th local (the `this` reference) is incorrect here and must be renamed. This PR renames all locals (including parameters) and stack elements with the old class name.