### PR TITLE
Mention possible location of error when missing properties for SubmissionWriteInfoTask

### DIFF
--- a/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/task/submission/SubmissionWriteInfoTask.kt
+++ b/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/task/submission/SubmissionWriteInfoTask.kt
@@ -60,7 +60,8 @@ abstract class SubmissionWriteInfoTask : WriteInfoTask(), SubmissionTask {
         if (errors.isNotEmpty()) {
             throw GradleException(
                 """
-There were some errors preparing your submission. The following required properties were not set:
+There were some errors preparing your submission, please check your Gradle buildscript (e.g. build.gradle.kts).
+The following required properties were not set:
 $errors
 """
             )


### PR DESCRIPTION
Mention the location of the Gradle buildscript, which is where the missing properties must be set most of the time.