### PR TITLE
Fix missing dependencies in gradle export

### DIFF
--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/export/submission/GradleSubmissionExporter.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/export/submission/GradleSubmissionExporter.kt
@@ -276,7 +276,6 @@ class GradleSubmissionExporter @Inject constructor(
             .flatMap { (sourceSet, dependencies) -> dependencies.map { sourceSet to it } }
             .filter { (_, dep) -> !dep.contains("org.sourcegrade:jagr-launcher") }
             .mapTo(mutableSetOf()) { "\"${it.first}\"(\"${it.second}\")" }
-            .toSet()
     }
 
     companion object {

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/export/submission/GradleSubmissionExporter.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/export/submission/GradleSubmissionExporter.kt
@@ -272,9 +272,11 @@ class GradleSubmissionExporter @Inject constructor(
     }
 
     private fun Map<String, Set<String>>.formatDependencies(): Set<String> {
-        return flatMap { (sourceSet, dependencies) -> dependencies.associateBy { sourceSet }.toList() }
+        return asSequence()
+            .flatMap { (sourceSet, dependencies) -> dependencies.map { sourceSet to it } }
             .filter { (_, dep) -> !dep.contains("org.sourcegrade:jagr-launcher") }
             .mapTo(mutableSetOf()) { "\"${it.first}\"(\"${it.second}\")" }
+            .toSet()
     }
 
     companion object {


### PR DESCRIPTION
The expresseion `.associateBy { sourceSet }` creates a HashMap that resulted in only one dependency being included from each dependency configuration (as the sourceSet key is shared between all dependencies for a given configuration).

This PR avoids creating a Map by directly mapping to a `List<Pair<String, String>>`.