### PR TITLE
Improve grader run task logging and failure message

### DIFF
--- a/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/task/grader/GraderRunTask.kt
+++ b/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/task/grader/GraderRunTask.kt
@@ -175,9 +175,9 @@ abstract class GraderRunTask : DefaultTask(), GraderTask {
             jagr.logger.info("Exported $rubricCount rubrics")
         }
         val rubricLocation = URI("file", "", rubricOutputDir.toURI().path + "result.html", null, null).toString()
-        jagr.logger.info("See rubric at $rubricLocation")
+        jagr.logger.info("See the rubric at $rubricLocation")
         if (failed) {
-            throw GradleException("Grading failed! See the rubric at $rubricLocation")
+            throw GradleException("Grading completed with failing tests! See the rubric at $rubricLocation")
         }
     }
 


### PR DESCRIPTION
Replace the "Grading failed!" message with "Grading completed with failing tests!" to be more explicit about the fact that there was no technical error but instead failing tests.