### PR TITLE
Fix total timeout not being triggered correctly

### DIFF
--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/executor/TimeoutHandler.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/executor/TimeoutHandler.kt
@@ -67,7 +67,7 @@ object TimeoutHandler {
             return
         }
         val currentThread = Thread.currentThread()
-        val userTime = mxBean.getThreadUserTime(currentThread.id) / 1000000
+        val userTime = mxBean.getThreadUserTime(currentThread.id) / 1_000_000L
         if (lastTimeout == 0L) {
             this.lastTimeout.get().set(userTime)
         } else if (userTime > timeoutTotal) {

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/executor/TimeoutHandler.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/executor/TimeoutHandler.kt
@@ -70,17 +70,16 @@ object TimeoutHandler {
         val userTime = mxBean.getThreadUserTime(currentThread.id) / 1000000
         if (lastTimeout == 0L) {
             this.lastTimeout.get().set(userTime)
+        } else if (userTime > timeoutTotal) {
+            val timeoutLocation = getTimeoutLocation()
+            logger.error("Total timeout after " + timeoutTotal + "ms @ " + currentThread.name, timeoutLocation)
+            throw AssertionFailedError("Total timeout after " + timeoutTotal + "ms")
         } else if (userTime - lastTimeout > timeoutIndividual) {
             val timeoutLocation = getTimeoutLocation()
-            if (userTime > timeoutTotal) {
-                logger.error("Total timeout after " + timeoutTotal + "ms @ " + currentThread.name, timeoutLocation)
-                throw AssertionFailedError("Total timeout after " + timeoutTotal + "ms")
-            } else {
-                logger.error("Timeout after " + timeoutIndividual + "ms @ " + currentThread.name, timeoutLocation)
-                // reset LAST_TIMEOUT so that the next JUnit test doesn't immediately fail
-                this.lastTimeout.get().set(userTime)
-                throw AssertionFailedError("Timeout after " + timeoutIndividual + "ms")
-            }
+            logger.error("Timeout after " + timeoutIndividual + "ms @ " + currentThread.name, timeoutLocation)
+            // reset LAST_TIMEOUT so that the next checkTimeout() invocation doesn't immediately fail
+            this.lastTimeout.get().set(userTime)
+            throw AssertionFailedError("Timeout after " + timeoutIndividual + "ms")
         }
     }
 


### PR DESCRIPTION
Due to #180, the `lastTimeout` property is reset before each test. This means that
`userTime - lastTimeout > timeoutIndividual` no longer implies `userTime > timeoutTotal`.

This caused the total timeout condition to not be accessible and essentially useless because the individual timeout must be reached per test before the total timeout can be triggered (defeating the purpose of a total timeout).

This PR extracts the nested if-statement so that the total timeout condition is correctly triggered.