### PR TITLE
Include studentId in submission file name

### DIFF
--- a/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/task/submission/SubmissionBuildTask.kt
+++ b/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/task/submission/SubmissionBuildTask.kt
@@ -26,10 +26,12 @@ abstract class SubmissionBuildTask : Jar(), SubmissionTask {
         val sourceSets = project.extensions.getByType<SourceSetContainer>()
         from(sourceSetNames.map { names -> names.map { name -> sourceSets[name].allSource } })
         archiveFileName.set(
-            assignmentId.zip(lastName) { assignmentId, lastName ->
-                "$assignmentId-$lastName"
+            assignmentId.zip(studentId) { assignmentId, studentId ->
+                "$assignmentId-$studentId"
             }.zip(firstName) { left, firstName ->
-                "$left-$firstName-submission"
+                "$left-$firstName"
+            }.zip(lastName) { left, lastName ->
+                "$left-$lastName-submission"
             }.zip(archiveExtension) { left, extension ->
                 "$left.$extension"
             }


### PR DESCRIPTION
Update the submission export file name to include the student id (and put the first name before the last name). For example:

Old:
`x02-LastName-FirstName-submission.jar`

New:
`x02-ab12cdef-FirstName-LastName-submission.jar`
