### PR TITLE
Add runtime configuration for ProcessWorker

### DIFF
--- a/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/task/grader/GraderRunTask.kt
+++ b/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/task/grader/GraderRunTask.kt
@@ -23,9 +23,7 @@ import org.sourcegrade.jagr.launcher.env.Jagr
 import org.sourcegrade.jagr.launcher.env.SystemResourceJagrFactory
 import org.sourcegrade.jagr.launcher.env.gradingQueueFactory
 import org.sourcegrade.jagr.launcher.env.logger
-import org.sourcegrade.jagr.launcher.executor.Executor
-import org.sourcegrade.jagr.launcher.executor.SyncExecutor
-import org.sourcegrade.jagr.launcher.executor.emptyCollector
+import org.sourcegrade.jagr.launcher.executor.*
 import org.sourcegrade.jagr.launcher.io.GradedRubricExporter
 import org.sourcegrade.jagr.launcher.io.GradingBatch
 import org.sourcegrade.jagr.launcher.io.ResourceContainer
@@ -145,7 +143,10 @@ abstract class GraderRunTask : DefaultTask(), GraderTask {
         }
         val queue = jagr.gradingQueueFactory.create(batch)
         jagr.logger.info("Executor mode 'gradle' :: expected submission: ${batch.expectedSubmissions}")
-        val executor: Executor = SyncExecutor(jagr)
+        val executor: Executor =
+            MultiWorkerExecutor.Factory {
+                workerPoolFactory = ProcessWorkerPool.Factory { concurrency = 1 }
+            }.create(jagr)
         val collector = emptyCollector(jagr)
         // TODO: Properly configure task output
         val rubricOutputDir = project.buildDir.resolve("resources/jagr/${configurationName.get()}/rubrics/")

--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/GradleTaskConfiguration.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/GradleTaskConfiguration.kt
@@ -1,0 +1,57 @@
+package org.sourcegrade.jagr.launcher.executor
+
+import org.sourcegrade.jagr.launcher.env.Jagr
+import org.spongepowered.configurate.objectmapping.ConfigSerializable
+import org.spongepowered.configurate.objectmapping.meta.Comment
+import java.io.File
+
+/**
+ * A Data class that stores the Runtime Configuration of jagr.
+ */
+@ConfigSerializable
+data class GradleTaskConfiguration(
+
+    val jagrVersion: String = Jagr.version,
+
+    /**
+     * The Path to the Jagr-Jar
+     */
+    @field:Comment("the Path to the Jagr-Jar")
+    val jagrJar: String? = null,
+
+    /**
+     * The Path to the java executable that will be used to run the child processes
+     */
+    @field:Comment("The Path to the java executable that will be used to run the child processes")
+    val javaExecutable: String = "java",
+
+    /**
+     * The JVM Arguments that will be passed to the child processes
+     */
+    @field:Comment("The JVM Arguments that will be passed to the child processes")
+    val jvmArgs: String = "",
+
+    /**
+     * Whether to enable the download of the Jagr-Jar if it is not found in the [jagrJar] location
+     */
+    @field:Comment("Whether to enable the download of the Jagr-Jar if it is not found in the [jagrJar] location")
+    val downloadIfMissing: Boolean = false,
+
+    /**
+     * The URL to download the Jagr-Jar from if it is not found at the [jagrJar] location and [downloadIfMissing] is true
+     */
+    @field:Comment("The URL to download the Jagr-Jar from if it is not found at the [jagrJar] location and [downloadIfMissing] is true")
+    val jagrDownloadURL: String? = null
+) {
+    // write a function that returns the parsed gradle task configuration
+    fun parsed(): ParsedGradleTaskConfiguration {
+        return ParsedGradleTaskConfiguration(
+            jagrVersion = jagrVersion,
+            jagrJar = jagrJar?.replace("%v", jagrVersion) ?: File(javaClass.protectionDomain.codeSource.location.toURI()).path,
+            javaExecutable = javaExecutable,
+            jvmArgs = jvmArgs,
+            downloadIfMissing = downloadIfMissing,
+            jagrDownloadURL = jagrDownloadURL?.replace("%v", jagrVersion)
+        )
+    }
+}

--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/ParsedGradleTaskConfiguration.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/ParsedGradleTaskConfiguration.kt
@@ -1,0 +1,45 @@
+package org.sourcegrade.jagr.launcher.executor
+
+import org.sourcegrade.jagr.launcher.env.Jagr
+import org.spongepowered.configurate.objectmapping.ConfigSerializable
+import org.spongepowered.configurate.objectmapping.meta.Comment
+
+/**
+ * A Data class that stores the Runtime Configuration of jagr.
+ */
+@ConfigSerializable
+data class ParsedGradleTaskConfiguration(
+
+    val jagrVersion: String = Jagr.version,
+
+    /**
+     * The Path to the Jagr-Jar
+     */
+    @field:Comment("the Path to the Jagr-Jar")
+    val jagrJar: String,
+
+    /**
+     * The Path to the java executable that will be used to run the child processes
+     */
+    @field:Comment("The Path to the java executable that will be used to run the child processes")
+    val javaExecutable: String = "java",
+
+    /**
+     * The JVM Arguments that will be passed to the child processes
+     */
+    @field:Comment("The JVM Arguments that will be passed to the child processes")
+    val jvmArgs: String = "",
+
+    /**
+     * Whether to enable the download of the Jagr-Jar if it is not found in the [jagrJar] location
+     */
+    @field:Comment("Whether to enable the download of the Jagr-Jar if it is not found in the [jagrJar] location")
+    val downloadIfMissing: Boolean = false,
+
+    /**
+     * The URL to download the Jagr-Jar from if it is not found at the [jagrJar] location and [downloadIfMissing] is true
+     */
+    @field:Comment("The URL to download the Jagr-Jar from if it is not found at the [jagrJar] location and [downloadIfMissing] is true")
+    val jagrDownloadURL: String? = null
+) {
+}

--- a/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/RuntimeConfiguration.kt
+++ b/launcher/src/main/kotlin/org/sourcegrade/jagr/launcher/executor/RuntimeConfiguration.kt
@@ -1,0 +1,55 @@
+package org.sourcegrade.jagr.launcher.executor
+
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+import java.io.File
+
+/**
+ * An interface that can be used to configure the Runtime of jagr. This is especially useful for gradle tasks.
+ */
+interface RuntimeConfiguration {
+    /**
+     * The [GradleTaskConfiguration] that is used to configure the Runtime of jagr.
+     */
+    val config: ParsedGradleTaskConfiguration
+
+    /**
+     * The [Logger] that is used to log messages.
+     */
+    val logger: Logger
+
+    /**
+     * A [RuntimeConfiguration] that is generated from the .jagrrc file in the current working directory.
+     */
+    object Standard : RuntimeConfiguration {
+        override val config: ParsedGradleTaskConfiguration by lazy {
+            val configFile = File(".jagrrc")
+            if (!configFile.exists()) {
+                configFile.createNewFile()
+            }
+            val options = configFile.readLines()
+                .map { it.trim().replace("#.*".toRegex(), "") }
+                .filter { it.isNotBlank() }
+                // split after the first '='
+                .map { it.split("=", limit = 2) }
+                .associate { it[0].trim() to it[1].trim() }
+            val defaultConfiguration = GradleTaskConfiguration()
+            val result: ParsedGradleTaskConfiguration = GradleTaskConfiguration(
+                jagrVersion = options["jagrVersion"] ?: defaultConfiguration.jagrVersion,
+                jagrJar = options["jagrJar"] ?: defaultConfiguration.jagrJar,
+                javaExecutable = options["javaExecutable"] ?: defaultConfiguration.javaExecutable,
+                jvmArgs = options["jvmArgs"] ?: defaultConfiguration.jvmArgs,
+                downloadIfMissing = options["downloadIfMissing"]?.toBoolean() ?: defaultConfiguration.downloadIfMissing,
+                jagrDownloadURL = options["jagrDownloadURL"] ?: defaultConfiguration.jagrDownloadURL,
+            ).parsed()
+            checkNotNull(result) { "Failed to load gradle task configuration" }
+        }
+
+        /**
+         * The [Logger] that is used to log messages.
+         */
+        override val logger: Logger by lazy {
+            LogManager.getLogger("Jagr")
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a runtime configuration called `.jagrrc` to the gradle execution. This will enable using the process mode with the gradle tasks for grading and fixes #83 and #155 .
The following features are archieved with this configuration:
- [x] the classloader is not reused for the next run which is required when loading native libraries
- [x] you can pass JVM args to the individual processes (necessary for testing javaFX)
- [x] you can adjust the java version and the jagr version being used
- [x] automatically downloads the desired jagr jar if it is not present
- [x] potential for even more runtime configuration options
- [ ] proper way of parsing the config file
- [ ] non-jank way of downloading and distributing the jar