### PR TITLE
Separate modules in submission artifact

### DIFF
--- a/launcher/gradle-plugin/src/jvmMain/kotlin/org/sourcegrade/jagr/gradle/extension/ProjectSourceSetTuple.kt
+++ b/launcher/gradle-plugin/src/jvmMain/kotlin/org/sourcegrade/jagr/gradle/extension/ProjectSourceSetTuple.kt
@@ -1,3 +1,22 @@
+/*
+ *   Jagr - SourceGrade.org
+ *   Copyright (C) 2021-2023 Alexander Städing
+ *   Copyright (C) 2021-2023 Contributors
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package org.sourcegrade.jagr.gradle.extension
 
 import org.gradle.api.Project
@@ -11,10 +30,10 @@ data class ProjectSourceSetTuple(
     val sourceSetName: String,
 ) : Serializable {
     companion object {
-        fun fromSourceSetNames(projectPath: String, sourceSetNames: Sequence<String>) =
+        fun fromSourceSetNames(projectPath: String, sourceSetNames: Sequence<String>): Set<ProjectSourceSetTuple> =
             sourceSetNames.map { ProjectSourceSetTuple(projectPath, it) }.toSet()
 
-        fun fromSourceSetNames(projectPath: String, sourceSetNames: Iterable<String>) =
+        fun fromSourceSetNames(projectPath: String, sourceSetNames: Iterable<String>): Set<ProjectSourceSetTuple> =
             fromSourceSetNames(projectPath, sourceSetNames.asSequence())
     }
 }

--- a/launcher/gradle-plugin/src/jvmMain/kotlin/org/sourcegrade/jagr/gradle/task/submission/SubmissionBuildTask.kt
+++ b/launcher/gradle-plugin/src/jvmMain/kotlin/org/sourcegrade/jagr/gradle/task/submission/SubmissionBuildTask.kt
@@ -1,10 +1,28 @@
+/*
+ *   Jagr - SourceGrade.org
+ *   Copyright (C) 2021-2023 Alexander Städing
+ *   Copyright (C) 2021-2023 Contributors
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package org.sourcegrade.jagr.gradle.task.submission
 
 import org.gradle.api.Project
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.InputFile
 import org.gradle.jvm.tasks.Jar
-import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.property
 import org.sourcegrade.jagr.gradle.extension.SubmissionConfiguration
 import org.sourcegrade.jagr.gradle.extension.getSourceSet
@@ -22,7 +40,19 @@ abstract class SubmissionBuildTask : Jar(), SubmissionTask {
         group = "build"
         dependsOn(configurationName.map(SubmissionWriteInfoTask.Factory::determineTaskName))
         from(submissionInfoFile)
-        from(sourceSetNames.map { all -> all.map { it.getSourceSet(project).allSource } })
+
+        project.subprojects.forEach { subproject ->
+            from(
+                sourceSetNames.map { all ->
+                    all
+                        .filter { it.projectPath == subproject.path }
+                        .map { it.getSourceSet(project).allSource }
+                },
+            ) { copy ->
+                copy.into(subproject.path)
+            }
+        }
+
         archiveFileName.set(
             assignmentId.zip(studentId) { assignmentId, studentId ->
                 "$assignmentId-$studentId"


### PR DESCRIPTION
Currently, the submission archive is created by flattening all modules and source sets into a single source zip/jar. While this works well for single-module projects, it is not optimal for multiple modules.

This PR is part of a larger effort to make Jagr more module-aware. The first step is to split up modules in the submission archive similarly to the way modules are split up in subfolders during development. Modules are significantly more logically separate units than source sets (e.g. different classpath, dependencies etc...) so it makes sense to split them up into subfolders for the submission.

For now, source sets will continue to be flattened into one module output.