### PR TITLE
Encode UTF strings with 4 bytes instead of 2 

### DIFF
--- a/core/src/jvmMain/kotlin/org/sourcegrade/jagr/core/compiler/java/JavaSourceFile.kt
+++ b/core/src/jvmMain/kotlin/org/sourcegrade/jagr/core/compiler/java/JavaSourceFile.kt
@@ -20,8 +20,7 @@
 package org.sourcegrade.jagr.core.compiler.java
 
 import org.sourcegrade.jagr.api.testing.SourceFile
-import org.sourcegrade.jagr.launcher.io.SerializationScope
-import org.sourcegrade.jagr.launcher.io.SerializerFactory
+import org.sourcegrade.jagr.launcher.io.*
 import java.net.URI
 import javax.tools.JavaFileObject.Kind
 import javax.tools.SimpleJavaFileObject
@@ -38,12 +37,12 @@ data class JavaSourceFile(
 
     companion object Factory : SerializerFactory<JavaSourceFile> {
         override fun read(scope: SerializationScope.Input): JavaSourceFile =
-            JavaSourceFile(scope.input.readUTF(), scope.input.readUTF(), scope.input.readUTF())
+            JavaSourceFile(scope.input.readUTF(), scope.input.readUTF(), scope.input.readText())
 
         override fun write(obj: JavaSourceFile, scope: SerializationScope.Output) {
             scope.output.writeUTF(obj.className)
             scope.output.writeUTF(obj.fileName)
-            scope.output.writeUTF(obj.content)
+            scope.output.writeText(obj.content)
         }
     }
 }

--- a/core/src/jvmMain/kotlin/org/sourcegrade/jagr/core/compiler/java/JavaSourceFile.kt
+++ b/core/src/jvmMain/kotlin/org/sourcegrade/jagr/core/compiler/java/JavaSourceFile.kt
@@ -20,7 +20,10 @@
 package org.sourcegrade.jagr.core.compiler.java
 
 import org.sourcegrade.jagr.api.testing.SourceFile
-import org.sourcegrade.jagr.launcher.io.*
+import org.sourcegrade.jagr.launcher.io.SerializationScope
+import org.sourcegrade.jagr.launcher.io.SerializerFactory
+import org.sourcegrade.jagr.launcher.io.readText
+import org.sourcegrade.jagr.launcher.io.writeText
 import java.net.URI
 import javax.tools.JavaFileObject.Kind
 import javax.tools.SimpleJavaFileObject

--- a/launcher/src/jvmMain/kotlin/org/sourcegrade/jagr/launcher/io/DataUtils.kt
+++ b/launcher/src/jvmMain/kotlin/org/sourcegrade/jagr/launcher/io/DataUtils.kt
@@ -56,7 +56,7 @@ fun ByteArrayDataOutput.writeNotNull() {
 /**
  * Reads in a string that is longer than 65535 characters (the maximum supported by readUTF).
  *
- * Instead of writing only two bytes for the length, this method writes four bytes for the length.
+ * Instead of writing only two bytes for the length, this method uses four bytes for the length.
  */
 fun ByteArrayDataInput.readText(): String = readByteArray().decodeToString()
 fun ByteArrayDataOutput.writeText(text: String) = writeByteArray(text.toByteArray())

--- a/launcher/src/jvmMain/kotlin/org/sourcegrade/jagr/launcher/io/DataUtils.kt
+++ b/launcher/src/jvmMain/kotlin/org/sourcegrade/jagr/launcher/io/DataUtils.kt
@@ -56,7 +56,7 @@ fun ByteArrayDataOutput.writeNotNull() {
 /**
  * Reads in a string that is longer than 65535 characters (the maximum supported by readUTF).
  *
- * Instead of writing only two bytes for the length, this method uses four bytes for the length.
+ * readUTF and writeUTF allocate the first 2 bytes for the length of the string, whereas this method allocates 4 bytes.
  */
 fun ByteArrayDataInput.readText(): String = readByteArray().decodeToString()
 fun ByteArrayDataOutput.writeText(text: String) = writeByteArray(text.toByteArray())

--- a/launcher/src/jvmMain/kotlin/org/sourcegrade/jagr/launcher/io/DataUtils.kt
+++ b/launcher/src/jvmMain/kotlin/org/sourcegrade/jagr/launcher/io/DataUtils.kt
@@ -52,3 +52,11 @@ fun ByteArrayDataOutput.writeNull() {
 fun ByteArrayDataOutput.writeNotNull() {
     writeByte(1)
 }
+
+/**
+ * Reads in a string that is longer than 65535 characters (the maximum supported by readUTF).
+ *
+ * Instead of writing only two bytes for the length, this method writes four bytes for the length.
+ */
+fun ByteArrayDataInput.readText(): String = readByteArray().decodeToString()
+fun ByteArrayDataOutput.writeText(text: String) = writeByteArray(text.toByteArray())


### PR DESCRIPTION
Fixes #243.

Java's standard writeUTF and readUTF methods encode the length of the UTF-8 String in 2 bytes. This implies a maximum length of 65535 bytes. This PR replaces the default serialization mechanism with custom readText + writeText methods that encode the length of the String in 4 bytes.