### PR TITLE
Fix compilation check not testing correct source sets

### DIFF
--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/executor/BatchCompilation.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/executor/BatchCompilation.kt
@@ -76,9 +76,10 @@ class CompiledBatchFactoryImpl @Inject constructor(
         // maps assignment ids to files that should be replaced with solution files
         val replacements = submissionFileOverrides.mapValues { (assignmentId, solutionOverrides) ->
             val gradersForAssignment = graders.filter { it.info.assignmentId == assignmentId }
-            solutionOverrides.mapNotNull { solutionOverride ->
+            val t: Map<String, JavaSourceFile> = solutionOverrides.mapNotNull { solutionOverride ->
                 gradersForAssignment.firstNotNullOfOrNull { it.container.source.sourceFiles[solutionOverride] }
             }.associateBy { it.fileName }
+            t
         }
 
         val submissions: List<Submission> = batch.submissions.compile(

--- a/core/src/main/kotlin/org/sourcegrade/jagr/core/executor/BatchCompilation.kt
+++ b/core/src/main/kotlin/org/sourcegrade/jagr/core/executor/BatchCompilation.kt
@@ -76,10 +76,9 @@ class CompiledBatchFactoryImpl @Inject constructor(
         // maps assignment ids to files that should be replaced with solution files
         val replacements = submissionFileOverrides.mapValues { (assignmentId, solutionOverrides) ->
             val gradersForAssignment = graders.filter { it.info.assignmentId == assignmentId }
-            val t: Map<String, JavaSourceFile> = solutionOverrides.mapNotNull { solutionOverride ->
+            solutionOverrides.mapNotNull { solutionOverride ->
                 gradersForAssignment.firstNotNullOfOrNull { it.container.source.sourceFiles[solutionOverride] }
             }.associateBy { it.fileName }
-            t
         }
 
         val submissions: List<Submission> = batch.submissions.compile(

--- a/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/extension/AbstractConfiguration.kt
+++ b/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/extension/AbstractConfiguration.kt
@@ -82,6 +82,8 @@ abstract class AbstractConfiguration(
         }
     }
 
+    fun getCompileJavaTaskNames(): List<String> = sourceSets.map { it.compileJavaTaskName }
+
     @JvmOverloads
     internal fun getAllDependencies(nameOverride: String? = null): Map<String, Set<String>> {
         return sourceSets.flatMap { sourceSet ->

--- a/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/extension/AbstractConfiguration.kt
+++ b/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/extension/AbstractConfiguration.kt
@@ -24,6 +24,7 @@ import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.provideDelegate
 import org.gradle.kotlin.dsl.setProperty
@@ -82,7 +83,11 @@ abstract class AbstractConfiguration(
         }
     }
 
-    fun getCompileJavaTaskNames(): List<String> = sourceSets.map { it.compileJavaTaskName }
+    internal fun getCompileJavaTaskNames(): List<String> {
+        return sourceSetNames.get().map { (projectPath, name) ->
+            projectPath + ":" + project.relative(projectPath).sourceSetContainer[name].compileJavaTaskName
+        }
+    }
 
     @JvmOverloads
     internal fun getAllDependencies(nameOverride: String? = null): Map<String, Set<String>> {

--- a/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/extension/AbstractConfiguration.kt
+++ b/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/extension/AbstractConfiguration.kt
@@ -25,6 +25,7 @@ import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.provideDelegate
 import org.gradle.kotlin.dsl.setProperty
 import java.util.Locale
 
@@ -36,27 +37,29 @@ abstract class AbstractConfiguration(
 
     private val dependencyConfiguration = DependencyConfiguration()
 
-    private val _sourceSets: MutableList<SourceSet> = mutableListOf()
-    val sourceSets: List<SourceSet>
-        get() = _sourceSets
-
     val sourceSetNames: SetProperty<ProjectSourceSetTuple> = project.objects.setProperty<ProjectSourceSetTuple>()
         .convention(ProjectSourceSetTuple.fromSourceSetNames("", sourceSetNamesConvention))
-
-    init {
-        project.afterEvaluate { proj ->
-            sourceSetNames.get().forEach { (projectPath, name) ->
-                val sourceSet = proj.relative(projectPath).sourceSetContainer.maybeCreate(name)
-                _sourceSets.add(sourceSet)
-            }
-            initialize(proj)
-        }
-    }
 
     private val Project.sourceSetContainer: SourceSetContainer
         get() = extensions.getByType()
 
-    private fun initialize(project: Project) {
+    val sourceSets: List<SourceSet> by lazy {
+        sourceSetNames.get().map { (projectPath, name) ->
+            project.relative(projectPath).sourceSetContainer.maybeCreate(name)
+        }
+    }
+
+    /**
+     * Configures the target project using information from this configuration.
+     *
+     * Must be called from a subclass in `project.afterEvaluate { }`.
+     */
+    protected fun configureProject() {
+        sourceSets
+        configureDependencies()
+    }
+
+    private fun configureDependencies() {
         project.dependencies {
             for ((suffix, dependencyNotations) in dependencyConfiguration.dependencies) {
                 val configurationName = if (name == "main") {

--- a/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/extension/GraderConfiguration.kt
+++ b/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/extension/GraderConfiguration.kt
@@ -55,6 +55,7 @@ abstract class GraderConfiguration(
 
     init {
         project.afterEvaluate {
+            configureProject()
             if (parentConfiguration.isPresent) {
                 addAsDependency(parentConfiguration.get())
             }

--- a/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/extension/SubmissionConfiguration.kt
+++ b/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/extension/SubmissionConfiguration.kt
@@ -32,6 +32,17 @@ abstract class SubmissionConfiguration(
     abstract val lastName: Property<String>
     val checkCompilation: Property<Boolean> = project.objects.property<Boolean>().convention(true)
 
+    init {
+        project.afterEvaluate {
+            configureProject()
+        }
+    }
+
+    /**
+     * Only available in `project.afterEvaluate { }`
+     */
+    fun getCompileJavaTaskNames(): List<String> = sourceSets.map { it.compileJavaTaskName }
+
     fun skipCompilationCheck() {
         checkCompilation.set(false)
     }

--- a/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/extension/SubmissionConfiguration.kt
+++ b/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/extension/SubmissionConfiguration.kt
@@ -38,11 +38,6 @@ abstract class SubmissionConfiguration(
         }
     }
 
-    /**
-     * Only available in `project.afterEvaluate { }`
-     */
-    fun getCompileJavaTaskNames(): List<String> = sourceSets.map { it.compileJavaTaskName }
-
     fun skipCompilationCheck() {
         checkCompilation.set(false)
     }

--- a/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/task/grader/GraderWriteInfoTask.kt
+++ b/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/task/grader/GraderWriteInfoTask.kt
@@ -53,11 +53,10 @@ abstract class GraderWriteInfoTask : WriteInfoTask(), GraderTask {
 
     init {
         group = "jagr resources"
-        dependsOn(
-            solutionConfigurationName
-                .flatMap { c -> submissionContainer[c].checkCompilation }
-                .map { if (it) "compileJava" else emptyList<String>() },
-        )
+        // add compilation dependency on solution
+        configureSubmissionCompilationDependency(solutionConfigurationName.map { submissionContainer[it] })
+        // add compilation dependency on grader source sets
+        dependsOn(configurationName.map { primaryContainer[it] }.map { it.getCompileJavaTaskNames() })
     }
 
     private fun GraderConfiguration.getFilesRecursive(): Map<String, Set<String>> {

--- a/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/task/submission/SubmissionWriteInfoTask.kt
+++ b/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/task/submission/SubmissionWriteInfoTask.kt
@@ -43,9 +43,11 @@ abstract class SubmissionWriteInfoTask : WriteInfoTask(), SubmissionTask {
     init {
         group = "jagr resources"
         dependsOn(
-            configurationName
-                .flatMap { c -> primaryContainer[c].checkCompilation }
-                .map { if (it) "compileJava" else emptyList<String>() },
+            configurationName.map { primaryContainer[it] }
+                .let { provider -> provider.zip(provider.flatMap { it.checkCompilation }, ::Pair) }
+                .map { (configuration, checkCompilation) ->
+                    if (checkCompilation) configuration.getCompileJavaTaskNames() else emptyList()
+                },
         )
         setOnlyIf {
             verifySubmit()

--- a/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/task/submission/SubmissionWriteInfoTask.kt
+++ b/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/task/submission/SubmissionWriteInfoTask.kt
@@ -42,13 +42,7 @@ abstract class SubmissionWriteInfoTask : WriteInfoTask(), SubmissionTask {
 
     init {
         group = "jagr resources"
-        dependsOn(
-            configurationName.map { primaryContainer[it] }
-                .let { provider -> provider.zip(provider.flatMap { it.checkCompilation }, ::Pair) }
-                .map { (configuration, checkCompilation) ->
-                    if (checkCompilation) configuration.getCompileJavaTaskNames() else emptyList()
-                },
-        )
+        configureSubmissionCompilationDependency(configurationName.map { primaryContainer[it] })
         setOnlyIf {
             verifySubmit()
             true


### PR DESCRIPTION
The `WriteInfoTask` (and by extension `BuildSubmissionTask`) is responsible for ensuring the submission compiles before creating a submission archive. This check also occurs when creating a grader archive. Previously, this only tested the main source set because of this code:

https://github.com/sourcegrade/jagr/blob/9f2f2e9ccca06f537685f95909ebea55f90d30fe/launcher/gradle-plugin/src/main/kotlin/org/sourcegrade/jagr/gradle/task/submission/SubmissionWriteInfoTask.kt#L43-L49

Instead of compiling the entire project, the `compileJava` task will only compile the main source set as defined [here](https://docs.gradle.org/current/userguide/java_plugin.html#sec:java_tasks)

This PR fixes this issue by adjusting the task dependency in the `WriteInfoTask` to the task responsible for compiling the source sets specifically for this submission.